### PR TITLE
New GitLab pipeline using common base image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 # Generated from templates/.gitlab-ci.yml.njk. Do not edit directly.
 
-image: quay.io/sbaird/rhtap-ci-images:rhtap-runner-gitlab
+image: quay.io/redhat-appstudio/dance-bootstrap-app:rhtap-runner-gitlab
 
 variables:
   CI_TYPE: gitlab

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,55 +1,95 @@
+# Generated from templates/.gitlab-ci.yml.njk. Do not edit directly.
 
-image: alpine
+image: quay.io/sbaird/rhtap-ci-images:rhtap-runner-gitlab
 
-before_script:
-  - echo "RHTAP before_script"
-  - apk upgrade
-  - apk add git bash jq yq curl python3 buildah cosign syft podman fuse-overlayfs
-  - export CI_TYPE=gitlab
+variables:
+  CI_TYPE: gitlab
 
-after_script:
-  - echo "RHTAP after_script"
+stages:
+  - init
+  - build
+  - scan
+  - deploy
+  - summary
 
-build:
+init:
+  stage: init
+  script:
+    - echo "init:init"
+    - bash /work/rhtap/init.sh
+  artifacts:
+    paths:
+      - results/
+
+buildah-rhtap:
   stage: build
   script:
-    - echo "WARNING Cloning pre-1.3 of https://github.com/jduimovich/tssc-sample-jenkins"
-    - git clone -b pre-1.3  https://github.com/jduimovich/tssc-sample-jenkins.git
-    - cp rhtap/env.sh tssc-sample-jenkins/resources/env.sh
-    - echo "Init"
-    - bash tssc-sample-jenkins/resources/init.sh
-    - echo "Build"
-    - bash tssc-sample-jenkins/resources/buildah-rhtap.sh
-    - bash tssc-sample-jenkins/resources/cosign-sign-attest.sh
+    - echo "build:buildah-rhtap"
+    - bash /work/rhtap/buildah-rhtap.sh
   artifacts:
     paths:
       - results/
-      - tssc-sample-jenkins/
 
-scan:
-  stage: test
+cosign-sign-attest:
+  stage: build
+  needs: [buildah-rhtap]
   script:
-    - echo "Scan"
-    - bash tssc-sample-jenkins/resources/acs-deploy-check.sh
-    - bash tssc-sample-jenkins/resources/acs-image-check.sh
-    - bash tssc-sample-jenkins/resources/acs-image-scan.sh
+    - echo "build:cosign-sign-attest"
+    - bash /work/rhtap/cosign-sign-attest.sh
   artifacts:
     paths:
       - results/
-      - tssc-sample-jenkins/
 
-summary:
+acs-deploy-check:
+  stage: scan
+  script:
+    - echo "scan:acs-deploy-check"
+    - bash /work/rhtap/acs-deploy-check.sh
+  artifacts:
+    paths:
+      - results/
+
+acs-image-check:
+  stage: scan
+  script:
+    - echo "scan:acs-image-check"
+    - bash /work/rhtap/acs-image-check.sh
+  artifacts:
+    paths:
+      - results/
+
+acs-image-scan:
+  stage: scan
+  script:
+    - echo "scan:acs-image-scan"
+    - bash /work/rhtap/acs-image-scan.sh
+  artifacts:
+    paths:
+      - results/
+
+update-deployment:
   stage: deploy
   script:
-    - echo "Summary"
-    - bash tssc-sample-jenkins/resources/update-deployment.sh
-    - bash tssc-sample-jenkins/resources/show-sbom-rhdh.sh
-    - bash tssc-sample-jenkins/resources/summary.sh
+    - echo "deploy:update-deployment"
+    - bash /work/rhtap/update-deployment.sh
   artifacts:
     paths:
       - results/
-      - tssc-sample-jenkins/
 
+show-sbom-rhdh:
+  stage: summary
+  script:
+    - echo "summary:show-sbom-rhdh"
+    - bash /work/rhtap/show-sbom-rhdh.sh
+  artifacts:
+    paths:
+      - results/
 
-
-
+summary:
+  stage: summary
+  script:
+    - echo "summary:summary"
+    - bash /work/rhtap/summary.sh
+  artifacts:
+    paths:
+      - results/

--- a/Dockerfile.gitlab
+++ b/Dockerfile.gitlab
@@ -2,15 +2,24 @@
 # For use as a step runner for RHTAP GitLab CI pipelines
 #
 
-FROM docker.io/alpine:3
+FROM docker.io/redhat/ubi9-minimal:9.4
 
-# Todo: Specify versions on these dependencies
-RUN apk upgrade --no-cache && apk add --no-cache \
-  git bash jq yq curl python3 buildah cosign syft podman fuse-overlayfs
+# Todo:
+# - Pin all the versions (maybe)
+# - Don't hard code the arch and platform in curl downloads
+# - Use RH builds instead of upstream where possible
+# - Check the sigature files for the curl downloads
 
-# Todo: Don't hard code the arch and platform and maybe use a RH build instead of an upstream build
-RUN curl -sL https://github.com/enterprise-contract/ec-cli/releases/download/v0.6.61/ec_linux_amd64 \
-  -o /usr/bin/ec && chmod 755 /usr/bin/ec
+RUN \
+  microdnf upgrade --assumeyes --nodocs --setopt=keepcache=0 --refresh && \
+  microdnf -y --nodocs --setopt=keepcache=0 install which git-core jq python3.11 podman buildah podman fuse-overlayfs && \
+  ln -s /usr/bin/python3.11 /usr/bin/python3
+
+RUN \
+  curl -sL https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64 -o /usr/bin/yq && chmod 755 /usr/bin/yq && \
+  curl -sL https://github.com/sigstore/cosign/releases/download/v2.4.1/cosign-linux-amd64 -o /usr/bin/cosign && chmod 755 /usr/bin/cosign && \
+  curl -sL https://github.com/enterprise-contract/ec-cli/releases/download/v0.6.58/ec_linux_amd64 -o /usr/bin/ec && chmod 755 /usr/bin/ec && \
+  curl -sL https://github.com/anchore/syft/releases/download/v1.14.1/syft_1.14.1_linux_amd64.tar.gz | tar zxf - syft && mv syft /usr/bin/syft
 
 WORKDIR /work
 

--- a/Dockerfile.gitlab
+++ b/Dockerfile.gitlab
@@ -1,0 +1,19 @@
+#
+# For use as a step runner for RHTAP GitLab CI pipelines
+#
+
+FROM docker.io/alpine:3
+
+# Todo: Specify versions on these dependencies
+RUN apk upgrade --no-cache && apk add --no-cache \
+  git bash jq yq curl python3 buildah cosign syft podman fuse-overlayfs
+
+# Todo: Don't hard code the arch and platform and maybe use a RH build instead of an upstream build
+RUN curl -sL https://github.com/enterprise-contract/ec-cli/releases/download/v0.6.61/ec_linux_amd64 \
+  -o /usr/bin/ec && chmod 755 /usr/bin/ec
+
+WORKDIR /work
+
+COPY ./rhtap ./rhtap/
+
+CMD ["/bin/bash"]

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ FILES=\
   Jenkinsfile.gitops \
   Jenkinsfile.gitops-local-shell \
   .github/workflows/build-and-update-gitops.yml \
+  .gitlab-ci.yml \
   rhtap.groovy \
   rhtap/build-pipeline-steps.sh \
   rhtap/promote-pipeline-steps.sh \

--- a/Makefile
+++ b/Makefile
@@ -58,3 +58,27 @@ clean:
 .PHONY: install-deps
 install-deps:
 	@npm --prefix $(RENDER_DIR) install --frozen-lockfile
+
+#-----------------------------------------------------------------------------
+
+.PHONY: push-images
+push-images: push-image-gitlab
+
+.PHONY: push-images
+build-images: build-image-gitlab
+
+# Todo: Find a proper home for these, and add unique tags
+RUNNER_IMAGE_REPO=quay.io/$(USER)/rhtap-ci-images
+TAG_PREFIX=rhtap-runner
+
+.PHONY: push-image-%
+push-image-%: build-image-%
+	podman push $(RUNNER_IMAGE_REPO):$(TAG_PREFIX)-$*
+
+.PHONY: build-image-%
+build-image-%:
+	podman build -f Dockerfile.$* -t $(RUNNER_IMAGE_REPO):$(TAG_PREFIX)-$*
+
+.PHONY: run-image-%
+run-image-%:
+	podman run --rm -i -t $(RUNNER_IMAGE_REPO):$(TAG_PREFIX)-$*

--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,8 @@ push-images: push-image-gitlab
 .PHONY: push-images
 build-images: build-image-gitlab
 
-# Todo: Find a proper home for these, and add unique tags
-RUNNER_IMAGE_REPO=quay.io/$(USER)/rhtap-ci-images
+# Todo: Should probably add a unique tag also
+RUNNER_IMAGE_REPO=quay.io/redhat-appstudio/dance-bootstrap-app
 TAG_PREFIX=rhtap-runner
 
 .PHONY: push-image-%

--- a/rhtap/buildah-rhtap.sh
+++ b/rhtap/buildah-rhtap.sh
@@ -14,12 +14,9 @@ function build() {
 	buildah login -u $QUAY_IO_CREDS_USR -p $QUAY_IO_CREDS_PSW $IMAGE_REGISTRY
 	ERR=$?
 	if [ $ERR != 0 ]; then
-		echo "Failed login $IMAGE_REGISTRY for user $QUAY_IO_CREDS_USR "
+		echo "Failed buildah login $IMAGE_REGISTRY for user $QUAY_IO_CREDS_USR "
 		exit $ERR
 	fi
-	echo "Mirror buildah login info into ~/.docker/config.json for cosign"
-	echo "cat ${XDG_RUNTIME_DIR}/containers/auth.json > ~/.docker/config.json"
-	cat ${XDG_RUNTIME_DIR}/containers/auth.json > ~/.docker/config.json
 
 	# Check if the Dockerfile exists
 	SOURCE_CODE_DIR=.
@@ -73,6 +70,12 @@ function generate-sboms() {
 
 function upload-sbom() {
 	echo "Running $TASK_NAME:upload-sbom"
+	cosign login -u $QUAY_IO_CREDS_USR -p $QUAY_IO_CREDS_PSW $IMAGE_REGISTRY
+	ERR=$?
+	if [ $ERR != 0 ]; then
+		echo "Failed cosign login $IMAGE_REGISTRY for user $QUAY_IO_CREDS_USR "
+		exit $ERR
+	fi
 	cosign attach sbom --sbom $TEMP_DIR/files/sbom-cyclonedx.json --type cyclonedx "$IMAGE"
 }
 function delim() {

--- a/templates/.gitlab-ci.yml.njk
+++ b/templates/.gitlab-ci.yml.njk
@@ -1,0 +1,30 @@
+{%- include "do-not-edit.njk" -%}
+
+{#- Fixme: Don't hard-code a repo belonging to sbaird -#}
+image: quay.io/sbaird/rhtap-ci-images:rhtap-runner-gitlab
+
+variables:
+  CI_TYPE: gitlab
+
+stages:
+{%- for step in build_steps %}
+  - {{ step.name }}
+{%- endfor -%}
+
+{%- for step in build_steps -%}
+{%- for substep in step.substeps %}
+
+{{ substep }}:
+  stage: {{ step.name }}
+  {#- By default they run in parallel but this one can't -#}
+  {%- if substep == "cosign-sign-attest" %}
+  needs: [buildah-rhtap]
+  {%- endif %}
+  script:
+    - echo "{{ step.name }}:{{ substep }}"
+    - bash /work/rhtap/{{ substep }}.sh
+  artifacts:
+    paths:
+      - results/
+{%- endfor -%}
+{%- endfor %}

--- a/templates/.gitlab-ci.yml.njk
+++ b/templates/.gitlab-ci.yml.njk
@@ -1,7 +1,6 @@
 {%- include "do-not-edit.njk" -%}
 
-{#- Fixme: Don't hard-code a repo belonging to sbaird -#}
-image: quay.io/sbaird/rhtap-ci-images:rhtap-runner-gitlab
+image: quay.io/redhat-appstudio/dance-bootstrap-app:rhtap-runner-gitlab
 
 variables:
   CI_TYPE: gitlab


### PR DESCRIPTION
- Create a runner image that contains the bash scripts and required dependencies
- Use that base image in the GitLab pipeline
- Convert the GitLab pipeline to a template and make it more similar to the others
- Change how the docker credential is provided for cosign (see commit message for more detail)

Ref: [EC-928](https://issues.redhat.com/browse/EC-928)