### PR TITLE
Revert "Fix old cosign param used to skip rekor upload"

### DIFF
--- a/rhtap/cosign-sign-attest.sh
+++ b/rhtap/cosign-sign-attest.sh
@@ -48,7 +48,7 @@ function cosign-cmd() {
     # verifying with cosign, or --skip-rekor when verifying with ec.
     # (If you really want to use the upstream public Rekor then set your REKOR_HOST
     # environment var to "https://rekor.sigstore.dev".)
-    REKOR_OPT="--no-tlog-upload=true"
+    REKOR_OPT="--tlog-upload=false"
   fi
 
   FULL_IMAGE_REF=$(full-image-ref)


### PR DESCRIPTION
I had it backwards and my local cosign was unexpectedly old.

This reverts commit 9fa0561632323d73e4b54d1bee8f9826dd908de6.