### PR TITLE
Use runner image for GitHub

### DIFF
--- a/.github/workflows/build-and-update-gitops.yml
+++ b/.github/workflows/build-and-update-gitops.yml
@@ -8,10 +8,11 @@
 
 name: TSSC-Build-Attest-Scan-Deploy
 env:
+  CI_TYPE: github
   # 🖊️ EDIT to change the image registry settings.
   # Registries such as GHCR, Quay.io, and Docker Hub are supported.
-  IMAGE_REGISTRY: quay.io/jduimovich0   # ${{ secrets.IMAGE_REGISTRY }}
-  IMAGE_REGISTRY_USER: jduimovich0    # ${{ secrets.IMAGE_REGISTRY_USER }}
+  IMAGE_REGISTRY: ${{ secrets.IMAGE_REGISTRY }}
+  IMAGE_REGISTRY_USER: ${{ secrets.IMAGE_REGISTRY_USER }}
   IMAGE_REGISTRY_PASSWORD: ${{ secrets.IMAGE_REGISTRY_PASSWORD }}
 
   ROX_CENTRAL_ENDPOINT: ${{ secrets.ROX_CENTRAL_ENDPOINT }}
@@ -37,6 +38,8 @@ jobs:
     name: Build and send Image Update PR
     # ubuntu-20.04 can also be used.
     runs-on: ubuntu-24.04
+    container:
+      image: quay.io/redhat-appstudio/dance-bootstrap-app:rhtap-runner-github
     environment: production
 
     steps:
@@ -86,50 +89,43 @@ jobs:
         fetch-depth: '2'
     - name: Pre-init
       run: |
-        echo "WARNING Cloning pre-1.3 of https://github.com/jduimovich/tssc-sample-jenkins"
-        git clone -b pre-1.3  https://github.com/jduimovich/tssc-sample-jenkins.git tssc-sample-jenkins
-        echo "export CI_TYPE=github " > tssc-sample-jenkins/resources/env.sh
-        cat rhtap/env.sh >> tssc-sample-jenkins/resources/env.sh
-        cat tssc-sample-jenkins/resources/env.sh
-        # syft and cosign install
-        mkdir -p local-bin
-        pushd local-bin
-        wget -q https://github.com/sigstore/cosign/releases/download/v2.4.0/cosign-linux-amd64
-        wget -q https://github.com/anchore/syft/releases/download/v1.13.0/syft_1.13.0_linux_amd64.tar.gz
-        tar zxvf syft_1.13.0_linux_amd64.tar.gz
-        ls -al
-        sudo mv cosign-linux-amd64 /usr/bin/cosign
-        sudo chmod +x /usr/bin/cosign
-        sudo mv syft /usr/bin/syft
-        sudo chmod +x /usr/bin/syft
+        buildah --version
         syft --version
         cosign version
-        buildah --version
-        popd
+        ec version
     - name: Init
       run: |
         echo "Init"
-        bash tssc-sample-jenkins/resources/init.sh
+        echo "init"
+        bash /work/rhtap/init.sh
     - name: Build
       run: |
         echo "Build"
-        bash tssc-sample-jenkins/resources/buildah-rhtap.sh
-        bash tssc-sample-jenkins/resources/cosign-sign-attest.sh
+        echo "buildah-rhtap"
+        bash /work/rhtap/buildah-rhtap.sh
+        echo "cosign-sign-attest"
+        bash /work/rhtap/cosign-sign-attest.sh
     - name: Scan
       run: |
         echo "Scan"
-        bash tssc-sample-jenkins/resources/acs-deploy-check.sh
-        bash tssc-sample-jenkins/resources/acs-image-check.sh
-        bash tssc-sample-jenkins/resources/acs-image-scan.sh
+        echo "acs-deploy-check"
+        bash /work/rhtap/acs-deploy-check.sh
+        echo "acs-image-check"
+        bash /work/rhtap/acs-image-check.sh
+        echo "acs-image-scan"
+        bash /work/rhtap/acs-image-scan.sh
     - name: Deploy
       run: |
         echo "Deploy"
-        bash tssc-sample-jenkins/resources/update-deployment.sh
+        echo "update-deployment"
+        bash /work/rhtap/update-deployment.sh
     - name: Summary
       run: |
         echo "Summary"
-        bash tssc-sample-jenkins/resources/show-sbom-rhdh.sh
-        bash tssc-sample-jenkins/resources/summary.sh
+        echo "show-sbom-rhdh"
+        bash /work/rhtap/show-sbom-rhdh.sh
+        echo "summary"
+        bash /work/rhtap/summary.sh
     - name: Done
       run: |
         echo "Done"

--- a/templates/build-and-update-gitops.yml.njk
+++ b/templates/build-and-update-gitops.yml.njk
@@ -8,13 +8,15 @@
 
 name: TSSC-Build-Attest-Scan-Deploy
 env:
+  CI_TYPE: github
+
   {#-
     Todo: Use the secret list in data/data.yaml here
   #}
   # 🖊️ EDIT to change the image registry settings.
   # Registries such as GHCR, Quay.io, and Docker Hub are supported.
-  IMAGE_REGISTRY: quay.io/jduimovich0   # ${{ "secrets.IMAGE_REGISTRY" | inCurlies }}
-  IMAGE_REGISTRY_USER: jduimovich0    # ${{ "secrets.IMAGE_REGISTRY_USER" | inCurlies }}
+  IMAGE_REGISTRY: ${{ "secrets.IMAGE_REGISTRY" | inCurlies }}
+  IMAGE_REGISTRY_USER: ${{ "secrets.IMAGE_REGISTRY_USER" | inCurlies }}
   IMAGE_REGISTRY_PASSWORD: ${{ "secrets.IMAGE_REGISTRY_PASSWORD" | inCurlies }}
 
   ROX_CENTRAL_ENDPOINT: ${{ "secrets.ROX_CENTRAL_ENDPOINT" | inCurlies }}
@@ -40,6 +42,8 @@ jobs:
     name: Build and send Image Update PR
     # ubuntu-20.04 can also be used.
     runs-on: ubuntu-24.04
+    container:
+      image: quay.io/redhat-appstudio/dance-bootstrap-app:rhtap-runner-github
     environment: production
 
     steps:
@@ -92,33 +96,18 @@ jobs:
         fetch-depth: '2'
     - name: Pre-init
       run: |
-        echo "WARNING Cloning pre-1.3 of https://github.com/jduimovich/tssc-sample-jenkins"
-        git clone -b pre-1.3  https://github.com/jduimovich/tssc-sample-jenkins.git tssc-sample-jenkins
-        echo "export CI_TYPE=github " > tssc-sample-jenkins/resources/env.sh
-        cat rhtap/env.sh >> tssc-sample-jenkins/resources/env.sh
-        cat tssc-sample-jenkins/resources/env.sh
-        # syft and cosign install
-        mkdir -p local-bin
-        pushd local-bin
-        wget -q https://github.com/sigstore/cosign/releases/download/v2.4.0/cosign-linux-amd64
-        wget -q https://github.com/anchore/syft/releases/download/v1.13.0/syft_1.13.0_linux_amd64.tar.gz
-        tar zxvf syft_1.13.0_linux_amd64.tar.gz
-        ls -al
-        sudo mv cosign-linux-amd64 /usr/bin/cosign
-        sudo chmod +x /usr/bin/cosign
-        sudo mv syft /usr/bin/syft
-        sudo chmod +x /usr/bin/syft
+        buildah --version
         syft --version
         cosign version
-        buildah --version
-        popd
+        ec version
 
 {%- for step in build_steps %}
     - name: {{ step.name | title }}
       run: |
         echo "{{ step.name | title }}"
 {%- for substep in step.substeps %}
-        bash tssc-sample-jenkins/resources/{{ substep }}.sh
+        echo "{{ substep }}"
+        bash /work/rhtap/{{ substep }}.sh
 {%- endfor -%}
 {%- endfor %}
     - name: Done


### PR DESCRIPTION
I didn't get this working yet.

There's a `Error during unshare(CLONE_NEWUSER): Operation not permitted` error which makes me think it's something to do with running buildah in a container:

```
Running buildah-rhtap:build
Running Login
Error during unshare(CLONE_NEWUSER): Operation not permitted
time="2024-10-17T21:17:38Z" level=error msg="parsing PID \"\": strconv.Atoi: parsing \"\": invalid syntax"
time="2024-10-17T21:17:[38](https://github.com/simonbaird/rhtap-ci-tester/actions/runs/11393186912/job/31700934153#step:7:39)Z" level=error msg="(Unable to determine exit status)"
Failed buildah login *** for user ***
```

Ref: [RHTAP-3066](https://issues.redhat.com/browse/RHTAP-3066)