### PR TITLE
ci test script

### DIFF
--- a/.github/workflows/build-and-update-gitops.yml
+++ b/.github/workflows/build-and-update-gitops.yml
@@ -10,8 +10,8 @@ name: TSSC-Build-Attest-Scan-Deploy
 env:
   # 🖊️ EDIT to change the image registry settings.
   # Registries such as GHCR, Quay.io, and Docker Hub are supported.
-  IMAGE_REGISTRY: quay.io/jduimovich0   # ${{ secrets.IMAGE_REGISTRY }}
-  IMAGE_REGISTRY_USER: jduimovich0    # ${{ secrets.IMAGE_REGISTRY_USER }}
+  IMAGE_REGISTRY: ${{ secrets.IMAGE_REGISTRY }}
+  IMAGE_REGISTRY_USER: ${{ secrets.IMAGE_REGISTRY_USER }}
   IMAGE_REGISTRY_PASSWORD: ${{ secrets.IMAGE_REGISTRY_PASSWORD }}
 
   ROX_CENTRAL_ENDPOINT: ${{ secrets.ROX_CENTRAL_ENDPOINT }}
@@ -85,51 +85,44 @@ jobs:
       with:
         fetch-depth: '2'
     - name: Pre-init
-      run: |
-        echo "WARNING Cloning pre-1.3 of https://github.com/jduimovich/tssc-sample-jenkins"
-        git clone -b pre-1.3  https://github.com/jduimovich/tssc-sample-jenkins.git tssc-sample-jenkins
-        echo "export CI_TYPE=github " > tssc-sample-jenkins/resources/env.sh
-        cat rhtap/env.sh >> tssc-sample-jenkins/resources/env.sh
-        cat tssc-sample-jenkins/resources/env.sh
-        # syft and cosign install
-        mkdir -p local-bin
-        pushd local-bin
-        wget -q https://github.com/sigstore/cosign/releases/download/v2.4.0/cosign-linux-amd64
-        wget -q https://github.com/anchore/syft/releases/download/v1.13.0/syft_1.13.0_linux_amd64.tar.gz
-        tar zxvf syft_1.13.0_linux_amd64.tar.gz
-        ls -al
-        sudo mv cosign-linux-amd64 /usr/bin/cosign
-        sudo chmod +x /usr/bin/cosign
-        sudo mv syft /usr/bin/syft
-        sudo chmod +x /usr/bin/syft
+      run: | 
+        echo "Using  quay.io/redhat-appstudio/dance-bootstrap-app:rhtap-runner-github"
+        mkdir -p out
+        docker run -v $(pwd)/out:/out quay.io/redhat-appstudio/dance-bootstrap-app:rhtap-runner-github bash /work/copy-scripts.sh
+        tree out 
+        sudo chmod +x out/binaries/*
+        sudo mv out/binaries/* /usr/bin
+        cp out/rhtap/* rhtap
+        export CI_TYPE=github   
+        cat  rhtap/env.sh 
         syft --version
         cosign version
         buildah --version
-        popd
+        ec version
     - name: Init
       run: |
         echo "Init"
-        bash tssc-sample-jenkins/resources/init.sh
+        bash rhtap/init.sh
     - name: Build
       run: |
         echo "Build"
-        bash tssc-sample-jenkins/resources/buildah-rhtap.sh
-        bash tssc-sample-jenkins/resources/cosign-sign-attest.sh
+        bash rhtap/buildah-rhtap.sh
+        bash rhtap/cosign-sign-attest.sh
     - name: Scan
       run: |
         echo "Scan"
-        bash tssc-sample-jenkins/resources/acs-deploy-check.sh
-        bash tssc-sample-jenkins/resources/acs-image-check.sh
-        bash tssc-sample-jenkins/resources/acs-image-scan.sh
+        bash rhtap/acs-deploy-check.sh
+        bash rhtap/acs-image-check.sh
+        bash rhtap/acs-image-scan.sh
     - name: Deploy
       run: |
         echo "Deploy"
-        bash tssc-sample-jenkins/resources/update-deployment.sh
+        bash rhtap/update-deployment.sh
     - name: Summary
       run: |
         echo "Summary"
-        bash tssc-sample-jenkins/resources/show-sbom-rhdh.sh
-        bash tssc-sample-jenkins/resources/summary.sh
+        bash rhtap/show-sbom-rhdh.sh
+        bash rhtap/summary.sh
     - name: Done
       run: |
         echo "Done"

--- a/Dockerfile.github
+++ b/Dockerfile.github
@@ -5,3 +5,6 @@
 # in the future, so that's why there's a separate Dockerfile and tag.)
 #
 FROM quay.io/redhat-appstudio/dance-bootstrap-app:rhtap-runner-gitlab
+COPY copy-scripts.sh /work/copy-scripts.sh
+RUN  chmod 755 /work/copy-scripts.sh
+

--- a/build-pipeline.sh
+++ b/build-pipeline.sh
@@ -33,7 +33,7 @@ cp -r rhtap $BUILD/
 # ENV with params
 SETUP_ENV=$BUILD/rhtap/env.sh
 cp rhtap/env.template.sh $SETUP_ENV
-sed -i "s!\${{ values.image }}!quay.io/\${MY_QUAY_USER:-jduimovich0}/bootstrap!g" $SETUP_ENV
+sed -i "s!\${{ values.image }}!quay.io/$MY_QUAY_USER/bootstrap!g" $SETUP_ENV
 sed -i "s!\${{ values.dockerfile }}!Dockerfile!g" $SETUP_ENV
 sed -i "s!\${{ values.buildContext }}!.!g" $SETUP_ENV
 sed -i "s!\${{ values.repoURL }}!$OPTIONAL_REPO_UPDATE!g" $SETUP_ENV

--- a/ci-test.sh
+++ b/ci-test.sh
@@ -1,0 +1,100 @@
+
+# get local test repos to patch
+source setup-local-dev-repos.sh
+
+if [ $TEST_REPO_ORG == "redhat-appstudio" ]; then
+    echo "Cannot do CI testing using the redhat-appstudio org"
+    echo "You must create forks in your own org and set up MY_TEST_REPO_ORG (github) and MY_TEST_REPO_GITLAB_ORG"
+    exit
+fi
+
+function  updateGitAndQuayRefs() { 
+    sed -i "s!quay.io/redhat-appstudio!quay.io/$MY_QUAY_USER!g" $1
+    sed -i "s!https://github.com/redhat-appstudio!https://github.com/$MY_GITHUB_USER!g" $1 
+}
+#Jenkins 
+echo "Update Jenkins file in $BUILD and $GITOPS" 
+echo "Jenkins to reuse the Github repo" 
+cp Jenkinsfile $BUILD/Jenkinsfile   
+cp Jenkinsfile.gitops $GITOPS/Jenkinsfile
+updateGitAndQuayRefs $BUILD/Jenkinsfile
+updateGitAndQuayRefs $GITOPS/Jenkinsfile
+# ENV with params
+
+function updateBuild() { 
+    REPO=$1
+    GITOPS_REPO_UPDATE=$2
+    mkdir -p $REPO/rhtap
+    SETUP_ENV=$REPO/rhtap/env.sh
+    cp rhtap/env.template.sh $SETUP_ENV 
+    sed -i "s!\${{ values.image }}!quay.io/$MY_QUAY_USER/bootstrap!g" $SETUP_ENV
+    sed -i "s!\${{ values.dockerfile }}!Dockerfile!g" $SETUP_ENV
+    sed -i "s!\${{ values.buildContext }}!.!g" $SETUP_ENV
+    sed -i "s!\${{ values.repoURL }}!$GITOPS_REPO_UPDATE!g" $SETUP_ENV
+    # Set MY_REKOR_HOST and MY_TUF_MIRROR to 'none' if these services are not available
+    sed -i 's!export REKOR_HOST=.*$!export REKOR_HOST="\${MY_REKOR_HOST:-http://rekor-server.rhtap.svc}"!' $SETUP_ENV
+    sed -i 's!export TUF_MIRROR=.*$!export TUF_MIRROR="\${MY_TUF_MIRROR:-http://tuf.rhtap.svc}"!' $SETUP_ENV
+    echo "# Update forced CI test $(date)" >>$SETUP_ENV
+    updateGitAndQuayRefs $SETUP_ENV
+    cat $SETUP_ENV
+}
+# Repos on github and gitlab, github reused for Jenkins
+# source repos get the name of the corresponding GITOPS REPO
+updateBuild $BUILD $TEST_GITOPS_REPO
+updateBuild $GITOPS  
+updateBuild $GITLAB_BUILD $TEST_GITOPS_GITLAB_REPO
+updateBuild $GITLAB_GITOPS 
+
+# Gitlab CI  
+echo "Update .gitlab-ci.yml file in $BUILD and $GITOPS" 
+cp .gitlab-ci.yml $GITLAB_BUILD/.gitlab-ci.yml
+cp .gitlab-ci.gitops.yml $GITLAB_GITOPS/.gitlab-ci.yml
+
+updateGitAndQuayRefs $GITLAB_BUILD/.gitlab-ci.yml
+updateGitAndQuayRefs $GITLAB_GITOPS/.gitlab-ci.yml
+
+# Github Actions  
+echo "Update .github workflows in $BUILD and $GITOPS"  
+echo "WARNING No  .github workflows in $GITOPS"  
+cp -r .github $BUILD  
+# add  $GITOPS/.github/workflows/* when workflow exists
+for wf in $BUILD/.github/workflows/*
+do
+    echo "Fix WF $wf"
+    sed -i 's/workflow_dispatch/push, workflow_dispatch/g'  $wf
+    updateGitAndQuayRefs $wf
+    echo "-"
+done
+
+function updateRepos() {
+    REPO=$1  
+    echo 
+    echo "Updating $REPO" 
+    pushd $REPO
+    git add . 
+    git commit -m "Testing in CI"  
+    git push   
+    popd
+}
+
+# github 
+updateRepos $BUILD      
+updateRepos $GITOPS  
+# gitlab
+updateRepos $GITLAB_BUILD    
+updateRepos $GITLAB_GITOPS   
+
+bash hack/ghub-set-vars $TEST_BUILD_REPO 
+bash hack/ghub-set-vars $TEST_GITOPS_REPO  
+bash hack/glab-set-vars $(basename $TEST_BUILD_GITLAB_REPO) 
+bash hack/glab-set-vars $(basename $TEST_GITOPS_GITLAB_REPO)   
+
+echo "Github Build and Gitops Repos" 
+echo "Build: $TEST_BUILD_REPO"
+echo "Gitops: $TEST_GITOPS_REPO" 
+
+echo "Gitlab Build and Gitops Repos" 
+echo "Build: $TEST_BUILD_GITLAB_REPO"
+echo "Gitops: $TEST_GITOPS_GITLAB_REPO" 
+
+

--- a/copy-scripts.sh
+++ b/copy-scripts.sh
@@ -1,0 +1,11 @@
+
+
+echo "Copy scripts"  
+cp -r /work/rhtap /out/rhtap 
+mkdir -p /out/binaries
+for binary in yq cosign ec syft
+do
+    echo "binary $binary"
+    cp /usr/bin/$binary /out/binaries/$binary
+    chmod +x /out/binaries/$binary
+done

--- a/dev-build.dockerfile
+++ b/dev-build.dockerfile
@@ -1,0 +1,8 @@
+
+for git in  gitlab github
+do
+    IMG=quay.io/$MY_QUAY_USER/dance-bootstrap-app:rhtap-runner-$git
+    echo "Building and pushing $IMG"
+    docker buildx build . -f Dockerfile.$git -t $IMG
+    docker push $IMG
+done

--- a/hack/copy-to-tssc-templates
+++ b/hack/copy-to-tssc-templates
@@ -32,12 +32,12 @@ cp rhtap/env.template.sh $GITOPS_TEMPLATE/rhtap/env.sh
 cp Jenkinsfile.gitops $GITOPS_TEMPLATE/Jenkinsfile
 
 # shared lib portion
-cp rhtap/*.sh $JENKINS_SHARED_LIB/resources
+cp rhtap/* $JENKINS_SHARED_LIB/resources
 cp rhtap.groovy $JENKINS_SHARED_LIB/vars
 # skip the env files, they will be in the templates as per above copy
-rm $JENKINS_SHARED_LIB/resources/env.sh
-rm $JENKINS_SHARED_LIB/resources/env.template.sh
-rm $JENKINS_SHARED_LIB/resources/signing-secret-env.sh
+rm -rf $JENKINS_SHARED_LIB/resources/env.sh
+rm -rf $JENKINS_SHARED_LIB/resources/env.template.sh
+rm -rf $JENKINS_SHARED_LIB/resources/signing-secret-env.sh
 
 # gitlab
 GITLAB_SRC_TEMPLATE=$TEMPLATES/skeleton/ci/source-repo/gitlabci

--- a/hack/ghub-set-vars
+++ b/hack/ghub-set-vars
@@ -14,7 +14,7 @@ function setVars() {
     NAME=$1
     VALUE=$2
     echo "setting Secret $NAME in $REPO"
-    gh secret set $NAME -b $VALUE --org northdepot
+    gh secret set $NAME -b $VALUE  
 }
 
 setVars  IMAGE_REGISTRY quay.io/$QUAY_IO_CREDS_USR

--- a/promote-pipeline.sh
+++ b/promote-pipeline.sh
@@ -20,8 +20,8 @@ fi
 # RHTAP gitops directory for local test
 cp -r rhtap $GITOPS/rhtap
 SETUP_ENV=$GITOPS/rhtap/env.sh
-cp rhtap/env.template.sh $SETUP_ENV
-sed -i "s!\${{ values.image }}!quay.io/\${MY_QUAY_USER:-jduimovich0}/bootstrap!g" $SETUP_ENV
+cp rhtap/env.template.sh $SETUP_ENV 
+sed -i "s!\${{ values.image }}!quay.io/$MY_QUAY_USER/bootstrap!g" $SETUP_ENV
 sed -i "s!\${{ values.dockerfile }}!Dockerfile!g" $SETUP_ENV
 sed -i "s!\${{ values.buildContext }}!.!g" $SETUP_ENV
 sed -i "s!\${{ values.repoURL }}!!g" $SETUP_ENV

--- a/rhtap/acs-deploy-check.sh
+++ b/rhtap/acs-deploy-check.sh
@@ -10,10 +10,19 @@ function rox-deploy-check() {
 	#!/usr/bin/env bash
 	set +x
 
+
 	if [ "$DISABLE_ACS" == "true" ]; then
 		echo "DISABLE_ACS is set. No scans will be produced"
 		exit_with_success_result
 	fi
+	if [ "$DISABLE_GITOPS_UPDATE" == "true" ]; then
+		echo "DISABLE_GITOPS_UPDATE is set. No repo update will occur"
+		exit_with_success_result
+	fi
+	if [ -z "$GITOPS_REPO_URL" ]; then
+		echo "GITOPS_REPO_URL not set to a value, deployment will not be updated"
+		exit_with_success_result
+	fi 
 	if [ -z "$ROX_API_TOKEN" ]; then
 		echo "ROX_API_TOKEN is not set, demo will exit with success"
 		exit_with_success_result

--- a/rhtap/common.sh
+++ b/rhtap/common.sh
@@ -36,4 +36,5 @@ echo "Step: $TASK_NAME"
 echo "Results: $RESULTS"
 export PATH=$PATH:/usr/local/bin
 
-source $SCRIPTDIR/env.sh
+# env.sh comes from the users repo in rhtap/env.sh
+source $DIR/rhtap/env.sh

--- a/setup-local-dev-repos.sh
+++ b/setup-local-dev-repos.sh
@@ -1,55 +1,67 @@
-echo "Configure the repos for Innerloop dev"
-echo "Build can use a repo directly, gitops needs a forked repo."
-echo "Set MY_TEST_REPO_ORG to test your forks of the repos"
+echo "Configure the repos for Innerloop dev" 
 
 TEST_REPO_ORG="${MY_TEST_REPO_ORG:-redhat-appstudio}"
+TEST_REPO_GITLAB_ORG="${MY_TEST_REPO_GITLAB_ORG:-redhat-appstudio}"
+
+if [ $TEST_REPO_ORG == "redhat-appstudio" ]; then
+  echo "Build can use redhat-appstudio directly, gitops needs a forked repo." 
+  echo "Set up a github and gitlab fork in github and gitlab "
+  echo "Pass org names in MY_TEST_REPO_ORG and MY_TEST_REPO_GITLAB_ORG"
+fi 
+if [ $TEST_REPO_GITLAB_ORG == "redhat-appstudio" ]; then
+  echo "WARNING: Gitops may not use redhat-appstudio, gitops needs a forked repo." 
+  echo "Set up a github and gitlab fork in github and gitlab "
+  echo "Pass org names in MY_TEST_REPO_ORG and MY_TEST_REPO_GITLAB_ORG"
+fi 
 
 # this will be copied into a temp directory
 # pipelines will be pushed into it for local test
+# build and gitops on gitlab
 TEST_BUILD_REPO=https://github.com/$TEST_REPO_ORG/devfile-sample-nodejs-dance
 
-# This should be optional, if it doesn't exist
-# the build can continue
-TEST_GITOPS_REPO=https://github.com/$TEST_REPO_ORG/tssc-dev-gitops
+# These repos are all optional, if they don't exist, the build can continue
+TEST_GITOPS_REPO=https://github.com/$TEST_REPO_ORG/tssc-dev-gitops 
+TEST_BUILD_GITLAB_REPO=https://gitlab.com/$TEST_REPO_GITLAB_ORG/devfile-sample-nodejs-dance
+TEST_GITOPS_GITLAB_REPO=https://gitlab.com/$TEST_REPO_GITLAB_ORG/tssc-dev-gitops
 
-BUILD_EXISTS=$(curl -s -o /dev/null -I -w "%{http_code}" $TEST_BUILD_REPO)
-GITOPS_EXISTS=$(curl -s -o /dev/null -I -w "%{http_code}" $TEST_GITOPS_REPO)
-# 200 == exists
-# 404 == no exists
+function cloneIfRepoExists () { 
+    REPO=$1
+    DEST=$2 
+    echo "Test repo $repo and clone into $DEST"
 
+    REPO_EXISTS=$(curl -s -o /dev/null -I -w "%{http_code}" $REPO)
+    # 200 == exists
+    # 404 == does not exist
+    if [ $REPO_EXISTS == 200 ]; then
+      echo "Clone source: $REPO into : $DEST"
+      git clone --quiet $REPO $DEST > /dev/null
+    else
+      echo "Cannot find $REPO - skipping it"
+    fi
+}
+  
 # clone if repos exist, disable gitops
-BUILD=tmp/build
-GITOPS=tmp/gitops
-rm -rf $BUILD
-rm -rf $GITOPS
+# Github in build/gitops
+# Gitlab in gitlab-build, gitlab-gitops
 
-echo "Build Configuration: "
-if [ $BUILD_EXISTS == 200 ]; then
-  echo "Source: $TEST_BUILD_REPO"
-  echo "Local Source directory: $BUILD"
-  git clone --quiet $TEST_BUILD_REPO $BUILD > /dev/null
-else
-  echo "Cannot find build tets repo $TEST_BUILD_REPO"
-fi
-if [ $GITOPS_EXISTS == 200 ]; then
-  echo "Gitops: $TEST_GITOPS_REPO"
-  echo "Local Gitops directory: $GITOPS"
-  git clone --quiet $TEST_GITOPS_REPO $GITOPS  > /dev/null
-else
-  echo "Cannot use gitops repo $TEST_GITOPS_REPO"
-  echo "****************"
-  echo "Build will continue, but Gitops update will be disabled"
-  echo "****************"
-  TEST_GITOPS_REPO=""
-fi
+TMP_REPOS=tmp
+rm -rf $TMP_REPOS/*
+BUILD=$TMP_REPOS/build
+GITOPS=$TMP_REPOS/gitops
+GITLAB_BUILD=$TMP_REPOS/gitlab-build
+GITLAB_GITOPS=$TMP_REPOS/gitlab-gitops
+cloneIfRepoExists $TEST_BUILD_REPO $BUILD
+cloneIfRepoExists $TEST_GITOPS_REPO $GITOPS 
+cloneIfRepoExists $TEST_BUILD_GITLAB_REPO $GITLAB_BUILD
+cloneIfRepoExists $TEST_GITOPS_GITLAB_REPO $GITLAB_GITOPS  
 
-# WARNING - if GITOPS_REPO_URL is set, the update deployment will try to update
-# the gitops repo. Disable this here if the gitops repo is NOT
+# WARNING - if GITOPS_REPO_URL is set, update deployment will try to update
+# the gitops repo. Disable this here if the gitops repo is NOT a fork
 if [ $TEST_REPO_ORG == "redhat-appstudio" ]; then
   echo "------------- INFO-------------"
   echo "DISABLING GITOPS REPO UPDATE for the "redhat-appstudio" org"
   echo "This prevents random accidental updates to the shared repo by dev team members with access"
-  export DISABLE_GITOPS_UPDATE=true
+  export DISABLE_GITOPS_UPDATE=true 
   echo "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^"
   echo
 fi

--- a/templates/build-and-update-gitops.yml.njk
+++ b/templates/build-and-update-gitops.yml.njk
@@ -13,8 +13,8 @@ env:
   #}
   # 🖊️ EDIT to change the image registry settings.
   # Registries such as GHCR, Quay.io, and Docker Hub are supported.
-  IMAGE_REGISTRY: quay.io/jduimovich0   # ${{ "secrets.IMAGE_REGISTRY" | inCurlies }}
-  IMAGE_REGISTRY_USER: jduimovich0    # ${{ "secrets.IMAGE_REGISTRY_USER" | inCurlies }}
+  IMAGE_REGISTRY: ${{ "secrets.IMAGE_REGISTRY" | inCurlies }}
+  IMAGE_REGISTRY_USER: ${{ "secrets.IMAGE_REGISTRY_USER" | inCurlies }}
   IMAGE_REGISTRY_PASSWORD: ${{ "secrets.IMAGE_REGISTRY_PASSWORD" | inCurlies }}
 
   ROX_CENTRAL_ENDPOINT: ${{ "secrets.ROX_CENTRAL_ENDPOINT" | inCurlies }}
@@ -91,34 +91,27 @@ jobs:
       with:
         fetch-depth: '2'
     - name: Pre-init
-      run: |
-        echo "WARNING Cloning pre-1.3 of https://github.com/jduimovich/tssc-sample-jenkins"
-        git clone -b pre-1.3  https://github.com/jduimovich/tssc-sample-jenkins.git tssc-sample-jenkins
-        echo "export CI_TYPE=github " > tssc-sample-jenkins/resources/env.sh
-        cat rhtap/env.sh >> tssc-sample-jenkins/resources/env.sh
-        cat tssc-sample-jenkins/resources/env.sh
-        # syft and cosign install
-        mkdir -p local-bin
-        pushd local-bin
-        wget -q https://github.com/sigstore/cosign/releases/download/v2.4.0/cosign-linux-amd64
-        wget -q https://github.com/anchore/syft/releases/download/v1.13.0/syft_1.13.0_linux_amd64.tar.gz
-        tar zxvf syft_1.13.0_linux_amd64.tar.gz
-        ls -al
-        sudo mv cosign-linux-amd64 /usr/bin/cosign
-        sudo chmod +x /usr/bin/cosign
-        sudo mv syft /usr/bin/syft
-        sudo chmod +x /usr/bin/syft
+      run: | 
+        echo "Using  quay.io/redhat-appstudio/dance-bootstrap-app:rhtap-runner-github"
+        mkdir -p out
+        docker run -v $(pwd)/out:/out quay.io/redhat-appstudio/dance-bootstrap-app:rhtap-runner-github bash /work/copy-scripts.sh
+        tree out 
+        sudo chmod +x out/binaries/*
+        sudo mv out/binaries/* /usr/bin
+        cp out/rhtap/* rhtap
+        export CI_TYPE=github   
+        cat  rhtap/env.sh 
         syft --version
         cosign version
         buildah --version
-        popd
+        ec version 
 
 {%- for step in build_steps %}
     - name: {{ step.name | title }}
       run: |
         echo "{{ step.name | title }}"
 {%- for substep in step.substeps %}
-        bash tssc-sample-jenkins/resources/{{ substep }}.sh
+        bash rhtap/{{ substep }}.sh
 {%- endfor -%}
 {%- endfor %}
     - name: Done


### PR DESCRIPTION
PR contains changes to allow a ci-test.sh script to copy into the users repo and test the CI.

- test Jenkins, gitlab and github CI from current repo (uncommitted)
- updated images for gitlab and github
- update tasks to allow disable gitops updates
- auto-set secrets for use repos for testing
- Uses MY_QUAY_USER for images and MY_GITHUB_USER for git repo
- removal of personal github accounts 