### PR TITLE
Download SBOM in promotion pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,10 @@ TARGET_DIRS=\
   gitlabci
 
 define targets_for_ci_type
-generated/source-repo/$(1)/%: templates/source-repo/%.njk
+generated/source-repo/$(1)/%: templates/source-repo/%.njk templates/data.yaml
 	$$(build_recipe)
 
-generated/gitops-template/$(1)/%: templates/gitops-template/%.njk
+generated/gitops-template/$(1)/%: templates/gitops-template/%.njk templates/data.yaml
 	$$(build_recipe)
 
 endef
@@ -52,11 +52,11 @@ endef
 $(foreach target_dir,$(TARGET_DIRS),$(eval $(call targets_for_ci_type,$(target_dir))))
 
 # For the two pipeline-steps.sh files
-rhtap/%: templates/%.njk
+rhtap/%: templates/%.njk templates/data.yaml
 	$(build_recipe)
 
 # For rhtap.groovy
-%: templates/%.njk
+%: templates/%.njk templates/data.yaml
 	$(build_recipe)
 
 # This should produce a non-zero exit code if there are

--- a/generated/gitops-template/githubactions/.github/workflows/gitops-promotion.yml
+++ b/generated/gitops-template/githubactions/.github/workflows/gitops-promotion.yml
@@ -99,14 +99,16 @@ jobs:
         cosign version
         buildah --version
         ec version
-    - name: Compute Image Changes
-      run: |
-        echo "Compute Image Changes"
-        bash rhtap/gather-deploy-images.sh
     - name: Verify Ec
       run: |
         echo "Verify Ec"
+        bash rhtap/gather-deploy-images.sh
         bash rhtap/verify-enterprise-contract.sh
+    - name: Upload Sbom
+      run: |
+        echo "Upload Sbom"
+        bash rhtap/gather-images-to-upload-sbom.sh
+        bash rhtap/download-sbom-from-url-in-attestation.sh
     - name: Done
       run: |
         echo "Done"

--- a/generated/gitops-template/gitlabci/.gitlab-ci.yml
+++ b/generated/gitops-template/gitlabci/.gitlab-ci.yml
@@ -6,11 +6,11 @@ variables:
   CI_TYPE: gitlab
 
 stages:
-  - Compute Image Changes
   - Verify EC
+  - Upload SBOM
 
 gather-deploy-images:
-  stage: Compute Image Changes
+  stage: Verify EC
   script:
     - echo "gather-deploy-images"
     - bash /work/rhtap/gather-deploy-images.sh
@@ -25,6 +25,28 @@ verify-enterprise-contract:
   script:
     - echo "verify-enterprise-contract"
     - bash /work/rhtap/verify-enterprise-contract.sh
+  artifacts:
+    paths:
+      - results/
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+
+gather-images-to-upload-sbom:
+  stage: Upload SBOM
+  script:
+    - echo "gather-images-to-upload-sbom"
+    - bash /work/rhtap/gather-images-to-upload-sbom.sh
+  artifacts:
+    paths:
+      - results/
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+
+download-sbom-from-url-in-attestation:
+  stage: Upload SBOM
+  script:
+    - echo "download-sbom-from-url-in-attestation"
+    - bash /work/rhtap/download-sbom-from-url-in-attestation.sh
   artifacts:
     paths:
       - results/

--- a/generated/gitops-template/jenkins/Jenkinsfile
+++ b/generated/gitops-template/jenkins/Jenkinsfile
@@ -14,20 +14,24 @@ pipeline {
         COSIGN_PUBLIC_KEY = credentials('COSIGN_PUBLIC_KEY')
     }
     stages {
-        stage('Compute Image Changes') {
+        stage('Verify EC') {
             steps {
                 script {
                     rhtap.info('gather_deploy_images')
                     rhtap.gather_deploy_images()
+                    rhtap.info('verify_enterprise_contract')
+                    rhtap.verify_enterprise_contract()
                 }
             }
         }
 
-        stage('Verify EC') {
+        stage('Upload SBOM') {
             steps {
                 script {
-                    rhtap.info('verify_enterprise_contract')
-                    rhtap.verify_enterprise_contract()
+                    rhtap.info('gather_images_to_upload_sbom')
+                    rhtap.gather_images_to_upload_sbom()
+                    rhtap.info('download_sbom_from_url_in_attestation')
+                    rhtap.download_sbom_from_url_in_attestation()
                 }
             }
         }

--- a/rhtap.groovy
+++ b/rhtap.groovy
@@ -73,3 +73,11 @@ def gather_deploy_images( ) {
 def verify_enterprise_contract( ) {
     run_script ('verify-enterprise-contract.sh')
 }
+
+def gather_images_to_upload_sbom( ) {
+    run_script ('gather-images-to-upload-sbom.sh')
+}
+
+def download_sbom_from_url_in_attestation( ) {
+    run_script ('download-sbom-from-url-in-attestation.sh')
+}

--- a/rhtap/gather-deploy-images.sh
+++ b/rhtap/gather-deploy-images.sh
@@ -10,11 +10,16 @@ function get-images-per-env() {
     #!/bin/bash
     set -euo pipefail
 
+    ENVIRONMENTS=("$@")
+    if [[ "${#ENVIRONMENTS[@]}" -eq 0 ]]; then
+        ENVIRONMENTS=(development stage prod)
+    fi
+
     IMAGE_PATH='.spec.template.spec.containers[0].image'
     IMAGES_FILE=$HOMEDIR/all-images.txt
     component_name=$(yq .metadata.name application.yaml)
 
-    for env in development stage prod; do
+    for env in "${ENVIRONMENTS[@]}"; do
         yaml_path=components/${component_name}/overlays/${env}/deployment-patch.yaml
         image=$(yq "$IMAGE_PATH" "$yaml_path")
 
@@ -62,4 +67,4 @@ function get-images-per-env() {
 }
 
 # Task Steps
-get-images-per-env
+get-images-per-env "$@"

--- a/rhtap/gather-deploy-images.sh
+++ b/rhtap/gather-deploy-images.sh
@@ -23,6 +23,12 @@ function get-images-per-env() {
         yaml_path=components/${component_name}/overlays/${env}/deployment-patch.yaml
         image=$(yq "$IMAGE_PATH" "$yaml_path")
 
+        # Workaround for RHTAPBUGS-1284
+        if [[ "$image" =~ quay.io/redhat-appstudio/dance-bootstrap-app ]]; then
+            # Don't check the dance-bootstrap-app image
+            continue
+        fi
+
         if [ -n "$TARGET_BRANCH" ]; then
             prev_image=$(git show "origin/$TARGET_BRANCH:$yaml_path" | yq "$IMAGE_PATH")
             if [ "$prev_image" = "$image" ]; then

--- a/rhtap/gather-deploy-images.sh
+++ b/rhtap/gather-deploy-images.sh
@@ -44,7 +44,8 @@ function get-images-per-env() {
 
     if [ ! -s "$IMAGES_FILE" ]; then
         echo "No images to verify"
-        touch $RESULTS/IMAGES_TO_VERIFY
+        # create or truncate the IMAGES_TO_VERIFY file
+        true > $RESULTS/IMAGES_TO_VERIFY
         exit 0
     fi
 

--- a/rhtap/gather-images-to-upload-sbom.sh
+++ b/rhtap/gather-images-to-upload-sbom.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -o errexit -o nounset -o pipefail
+
+SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
+
+"$SCRIPTDIR/gather-deploy-images.sh" stage prod

--- a/rhtap/promote-pipeline-steps.sh
+++ b/rhtap/promote-pipeline-steps.sh
@@ -2,3 +2,5 @@
 
 run rhtap/gather-deploy-images.sh
 run rhtap/verify-enterprise-contract.sh
+run rhtap/gather-images-to-upload-sbom.sh
+run rhtap/download-sbom-from-url-in-attestation.sh

--- a/templates/data.yaml
+++ b/templates/data.yaml
@@ -24,10 +24,10 @@ build_secrets:
   - name: COSIGN_PUBLIC_KEY
 
 gitops_steps:
-  - name: Compute Image Changes
-    substeps: [gather-deploy-images]
   - name: Verify EC
-    substeps: [verify-enterprise-contract]
+    substeps: [gather-deploy-images, verify-enterprise-contract]
+  - name: Upload SBOM
+    substeps: [gather-images-to-upload-sbom, download-sbom-from-url-in-attestation]
 
 gitops_secrets:
   - name: COSIGN_PUBLIC_KEY


### PR DESCRIPTION
This is a hacky way to integrate the SBOM-downloading into the promotion pipeline

* We need to call the gather-images script twice with different params. Work around that by adding another script that calls it with the params we need.
* The second run of gather-images will just overwrite the results of the first one. This is fine at the moment, because the entire pipeline runs serially (I think?). It would still be possible to run the two `gitops_steps` in parallel if they each ran in a separate environment.