### PR TITLE
Ignore `.envrc` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ tmp/
 node_modules/
 rhtap/signing-secret-env.sh
 render/node_modules/
+.envrc


### PR DESCRIPTION
Used by direnv[1] to set per directory environment variables.

[1] https://github.com/direnv/direnv