### PR TITLE
update scripts for generated files

### DIFF
--- a/ci-test.sh
+++ b/ci-test.sh
@@ -7,20 +7,24 @@ if [ $TEST_REPO_ORG == "redhat-appstudio" ]; then
     exit
 fi
 
-function updateGitAndQuayRefs() {
-    sed -i "s!quay.io/redhat-appstudio!quay.io/$MY_QUAY_USER!g" $1
-    sed -i "s!https://github.com/redhat-appstudio!https://github.com/$MY_GITHUB_USER!g" $1
+function  updateGitAndQuayRefs() { 
+    if [ -f $1 ]; then
+        sed -i "s!quay.io/redhat-appstudio!quay.io/$MY_QUAY_USER!g" $1
+        sed -i "s!https://github.com/redhat-appstudio!https://github.com/$MY_GITHUB_USER!g" $1 
+    fi 
 }
-#Jenkins
-echo "Update Jenkins file in $BUILD and $GITOPS"
-echo "Jenkins to reuse the Github repo"
-cp Jenkinsfile $BUILD/Jenkinsfile
-cp Jenkinsfile.gitops $GITOPS/Jenkinsfile
+#Jenkins 
+echo "Update Jenkins file in $BUILD and $GITOPS" 
+echo "Jenkins is able to reuse the same Github repo as github actions" 
+GEN_SRC=generated/source-repo
+GEN_GITOPS=generated/gitops-template   
+
+cp $GEN_SRC/jenkins/Jenkinsfile $BUILD/Jenkinsfile  
+cp $GEN_GITOPS/jenkins/Jenkinsfile $GITOPS/Jenkinsfile    
 updateGitAndQuayRefs $BUILD/Jenkinsfile
 updateGitAndQuayRefs $GITOPS/Jenkinsfile
-# ENV with params
-
-function updateBuild() {
+ 
+function updateBuild() { 
     REPO=$1
     GITOPS_REPO_UPDATE=$2
     mkdir -p $REPO/rhtap
@@ -44,24 +48,20 @@ updateBuild $GITOPS
 updateBuild $GITLAB_BUILD $TEST_GITOPS_GITLAB_REPO
 updateBuild $GITLAB_GITOPS
 
-# Gitlab CI
-echo "Update .gitlab-ci.yml file in $BUILD and $GITOPS"
-cp .gitlab-ci.yml $GITLAB_BUILD/.gitlab-ci.yml
-cp .gitlab-ci.gitops.yml $GITLAB_GITOPS/.gitlab-ci.yml
-
+# Gitlab CI  
+echo "Update .gitlab-ci.yml file in $GITLAB_BUILD and $GITLAB_GITOPS" 
+cp $GEN_SRC/gitlabci/.gitlab-ci.yml $GITLAB_BUILD/.gitlab-ci.yml
+cp $GEN_GITOPS/gitlabci/.gitlab-ci.yml $GITLAB_GITOPS/.gitlab-ci.yml 
 updateGitAndQuayRefs $GITLAB_BUILD/.gitlab-ci.yml
 updateGitAndQuayRefs $GITLAB_GITOPS/.gitlab-ci.yml
 
-# Github Actions
-echo "Update .github workflows in $BUILD and $GITOPS"
-echo "WARNING No  .github workflows in $GITOPS"
-cp -r .github $BUILD
-# add  $GITOPS/.github/workflows/* when workflow exists
-for wf in $BUILD/.github/workflows/*; do
-    echo "Fix WF $wf"
-    sed -i 's/workflow_dispatch/push, workflow_dispatch/g' $wf
-    updateGitAndQuayRefs $wf
-    echo "-"
+# Github Actions  
+echo "Update .github workflows in $BUILD and $GITOPS"   
+cp -r $GEN_SRC/githubactions/.github $BUILD  
+cp -r $GEN_GITOPS/githubactions/.github $GITOPS   
+for wf in $BUILD/.github/workflows/* $GITOPS/.github/workflows/*
+do 
+    updateGitAndQuayRefs $wf 
 done
 
 function updateRepos() {

--- a/hack/copy-to-tssc-templates
+++ b/hack/copy-to-tssc-templates
@@ -34,32 +34,29 @@ fi
 # arg1   root-ci (pass source or gitops here)
 # arg2   ciType  - jenkins, gitlabci, githubactions
 # arg3   rhtap env.sh file -- allows different defaults if you want for local test
-# arg4   files-or-dir to copy to template dir (root-ci + ciType)
-# arg5   option rename for arg4  (ie Jenkinsfile.gitop -> Jenkinsfile)
+# arg4   files-or-dir to copy to template dir (root-ci + ciType) 
 # WARNING - this will WIPE the CI directory and copy the files there
 function update-tssc-templates() {
     ROOT_CI_LOCATION=$1
     CI_TYPE=$2
     RHTAP_ENV=$3
-    TEMPLATE_FILES=$4
-    DEST_FOLDER=$ROOT_CI_LOCATION/$CI_TYPE
-    echo "Updating $DEST_FOLDER"
+    TEMPLATE_FILES=$4 
+    SRC_FOLDER=$TEMPLATE_FILES/$CI_TYPE     # from generated folder CI_TYPE
+    DEST_FOLDER=$ROOT_CI_LOCATION/$CI_TYPE  # to template folder CI_TYPE 
+
+    echo "Updating $DEST_FOLDER from $SRC_FOLDER"
     rm -rf $DEST_FOLDER
     mkdir -p $DEST_FOLDER/rhtap
     cp $RHTAP_ENV $DEST_FOLDER/rhtap/env.sh
-    if [ -d $TEMPLATE_FILES ]; then
-        cp -r $TEMPLATE_FILES $DEST_FOLDER
-    else
-        cp $TEMPLATE_FILES $DEST_FOLDER/$5
-    fi
+    cp -r $SRC_FOLDER/. $DEST_FOLDER 
 }
 
 CI_ROOT_SRC=$TEMPLATES/skeleton/ci/source-repo
 CI_ROOT_GITOPS=$TEMPLATES/skeleton/ci/gitops-template
-# Jenkins templates
-update-tssc-templates $CI_ROOT_SRC jenkins rhtap/env.template.sh Jenkinsfile Jenkinsfile
-update-tssc-templates $CI_ROOT_GITOPS jenkins rhtap/env.template.sh Jenkinsfile.gitops Jenkinsfile
+GEN_SRC=generated/source-repo
+GEN_GITOPS=generated/gitops-template 
 
+# Jenkins   
 # shared lib for Jenkins
 # copy scripts and groovy files in to proper locations
 # delete extra files - We should move these outside of ./rhtap
@@ -72,13 +69,12 @@ cp rhtap.groovy $JENKINS_SHARED_LIB/vars
 rm -rf $JENKINS_SHARED_LIB/resources/env.template.sh
 rm -rf $JENKINS_SHARED_LIB/resources/signing-secret-env.sh
 
-# gitlab templates
-update-tssc-templates $CI_ROOT_SRC gitlabci rhtap/env.template.sh .gitlab-ci.yml .gitlab-ci.yml
-update-tssc-templates $CI_ROOT_GITOPS gitlabci rhtap/env.template.sh .gitlab-ci.gitops.yml .gitlab-ci.yml
-
-# github actions templates
-update-tssc-templates $CI_ROOT_SRC githubactions rhtap/env.template.sh generated/source-repo/githubactions/.github
-update-tssc-templates $CI_ROOT_GITOPS githubactions rhtap/env.template.sh generated/gitops-template/githubactions/.github
+# templates are copied 1-1
+for ciType in jenkins gitlabci githubactions 
+do 
+    update-tssc-templates $CI_ROOT_SRC $ciType rhtap/env.template.sh $GEN_SRC 
+    update-tssc-templates $CI_ROOT_GITOPS $ciType rhtap/env.template.sh $GEN_GITOPS 
+done   
 
 echo "You will have to manually commit any changes to template or jenkins files"
 echo "Validate the changes, and create a PR to update the templates and library files"


### PR DESCRIPTION
Update the copy scripts to reference the generated templates directory.
- copy-to-tssc-templates.sh copys the directory and contents so if/when we add techdocs it will update automatically
- ci-test only copies the specific CI files to avoid overwriting ther files in the test repos