### PR TITLE
Jenkins: install missing script

### DIFF
--- a/rhtap.groovy
+++ b/rhtap.groovy
@@ -21,6 +21,11 @@ def run_script (scriptname) {
       install_script ('merge_sboms.py')
     }
 
+    if (scriptname == 'cosign-sign-attest.sh') {
+      // Called from cosign-sign-attest.sh
+      install_script ('att-predicate-jenkins.sh')
+    }
+
     install_script (scriptname)
     sh "rhtap/${scriptname}"
 }

--- a/templates/rhtap.groovy.njk
+++ b/templates/rhtap.groovy.njk
@@ -21,6 +21,11 @@ def run_script (scriptname) {
       install_script ('merge_sboms.py')
     }
 
+    if (scriptname == 'cosign-sign-attest.sh') {
+      // Called from cosign-sign-attest.sh
+      install_script ('att-predicate-jenkins.sh')
+    }
+
     install_script (scriptname)
     sh "rhtap/${scriptname}"
 }


### PR DESCRIPTION
cosign-sign-attest.sh now depends on att-predicate-jenkins.sh, but the latter wasn't getting installed.