### PR TITLE
Jenkins: fix extra whitespace in secrets

### DIFF
--- a/hack/jenkins-create-secret
+++ b/hack/jenkins-create-secret
@@ -10,9 +10,7 @@ cat << CREDS > $CREDS
   <scope>GLOBAL</scope>
   <id>$SECRET_NAME</id>
   <description></description>
-  <secret>
-    $SECRET_VALUE
-  </secret>
+  <secret>$SECRET_VALUE</secret>
 </org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl>
 CREDS
 

--- a/hack/jenkins-create-user-password
+++ b/hack/jenkins-create-user-password
@@ -12,9 +12,7 @@ cat << CREDS > $CREDS
   <id>$SECRET_NAME</id>
   <description></description>
   <username>$USER_NAME</username>
-  <password>
-    $USER_PW
-  </password>
+  <password>$USER_PW</password>
   <usernameSecret>false</usernameSecret>
 </com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl>
 CREDS


### PR DESCRIPTION
Previously, the secrets were getting created with extra whitespace. Somehow this worked fine in *most* cases but not always. For example, the 'deploy' step in a build pipeline would fail with

    Failed to push update to gitops repository: https://github.com/acmiel-rhtap/rhtap-python-gitops
    Do you have correct git credentials configured?

After removing the extra whitespace, the step started working.