### PR TITLE
Comput rekor-tufs endpoints in-test script

### DIFF
--- a/ci-test.sh
+++ b/ci-test.sh
@@ -15,7 +15,6 @@ function updateGitAndQuayRefs() {
     fi
 }
 
-
 #Jenkins
 echo "Update Jenkins file in $BUILD and $GITOPS"
 echo "Jenkins is able to reuse the same Github repo as github actions"
@@ -36,15 +35,15 @@ function updateBuild() {
     sed -i "s!\${{ values.image }}!quay.io/$MY_QUAY_USER/bootstrap!g" $SETUP_ENV
     sed -i "s!\${{ values.dockerfile }}!Dockerfile!g" $SETUP_ENV
     sed -i "s!\${{ values.buildContext }}!.!g" $SETUP_ENV
-    sed -i "s!\${{ values.repoURL }}!$GITOPS_REPO_UPDATE!g" $SETUP_ENV 
+    sed -i "s!\${{ values.repoURL }}!$GITOPS_REPO_UPDATE!g" $SETUP_ENV
     # Update REKOR_HOST and TUF_MIRROR values directly
-    sed -i '/export REKOR_HOST=/d' $SETUP_ENV  
-    sed -i '/export TUF_MIRROR=/d' $SETUP_ENV 
-    echo "export REKOR_HOST=$REKOR_HOST" >>  $SETUP_ENV 
-    echo "export TUF_MIRROR=$TUF_MIRROR" >>  $SETUP_ENV  
+    sed -i '/export REKOR_HOST=/d' $SETUP_ENV
+    sed -i '/export TUF_MIRROR=/d' $SETUP_ENV
+    echo "export REKOR_HOST=$REKOR_HOST" >> $SETUP_ENV
+    echo "export TUF_MIRROR=$TUF_MIRROR" >> $SETUP_ENV
     echo "# Update forced CI test $(date)" >> $SETUP_ENV
     updateGitAndQuayRefs $SETUP_ENV
-    cat $SETUP_ENV 
+    cat $SETUP_ENV
 }
 # Repos on github and gitlab, github reused for Jenkins
 # source repos get the name of the corresponding GITOPS REPO

--- a/init-tas-vars.sh
+++ b/init-tas-vars.sh
@@ -1,12 +1,25 @@
-# init tuf and REKOR
+# init Tuf and REKOR
+# for local build and CI we set REKOR_HOST and TUF_MIRROR 
 
-RT=$(oc get routes -n rhtap-tas -o name | grep rekor-server)
-HOST=$(oc get -n rhtap-tas $RT -o jsonpath={.spec.host})
-export REKOR_HOST=https://$HOST
+echo "Checking for REKOR and TUF" 
 
-RT=$(oc get routes -n rhtap-tas -o name | grep tuf)
-HOST=$(oc get -n rhtap-tas $RT -o jsonpath={.spec.host})
-export TUF_MIRROR=https://$HOST
+# get hosts, if errors occur or cannot find routes, set to none
+RT=$(oc get routes -n rhtap-tas -o name 2>  /dev/null | grep rekor-server )
+if [[ $RT == "" ]]; then 
+    export REKOR_HOST=none 
+else
+    HOST=$(oc get -n rhtap-tas $RT -o jsonpath={.spec.host})
+    export REKOR_HOST=https://$HOST
+fi 
+
+RT=$(oc get routes -n rhtap-tas -o name 2>  /dev/null| grep tuf)
+if [[ $RT == "" ]]; then 
+    export TUF_MIRROR=none 
+else
+    HOST=$(oc get -n rhtap-tas $RT -o jsonpath={.spec.host})
+    export TUF_MIRROR=https://$HOST
+fi 
+
 
 echo "REKOR_HOST set to $REKOR_HOST"
 echo "TUF_MIRROR set to $TUF_MIRROR"

--- a/init-tas-vars.sh
+++ b/init-tas-vars.sh
@@ -6,7 +6,7 @@ echo "Checking for REKOR and TUF"
 # get hosts, if errors occur or cannot find routes, set to none
 RT=$(oc get routes -n rhtap-tas -o name 2>  /dev/null | grep rekor-server )
 if [[ $RT == "" ]]; then 
-    export REKOR_HOST=none 
+    export REKOR_HOST=''
 else
     HOST=$(oc get -n rhtap-tas $RT -o jsonpath={.spec.host})
     export REKOR_HOST=https://$HOST
@@ -14,7 +14,7 @@ fi
 
 RT=$(oc get routes -n rhtap-tas -o name 2>  /dev/null| grep tuf)
 if [[ $RT == "" ]]; then 
-    export TUF_MIRROR=none 
+    export TUF_MIRROR='' 
 else
     HOST=$(oc get -n rhtap-tas $RT -o jsonpath={.spec.host})
     export TUF_MIRROR=https://$HOST

--- a/init-tas-vars.sh
+++ b/init-tas-vars.sh
@@ -1,25 +1,24 @@
 # init Tuf and REKOR
-# for local build and CI we set REKOR_HOST and TUF_MIRROR 
+# for local build and CI we set REKOR_HOST and TUF_MIRROR
 
-echo "Checking for REKOR and TUF" 
+echo "Checking for REKOR and TUF"
 
 # get hosts, if errors occur or cannot find routes, set to none
-RT=$(oc get routes -n rhtap-tas -o name 2>  /dev/null | grep rekor-server )
-if [[ $RT == "" ]]; then 
+RT=$(oc get routes -n rhtap-tas -o name 2> /dev/null | grep rekor-server)
+if [[ $RT == "" ]]; then
     export REKOR_HOST=''
 else
     HOST=$(oc get -n rhtap-tas $RT -o jsonpath={.spec.host})
     export REKOR_HOST=https://$HOST
-fi 
+fi
 
-RT=$(oc get routes -n rhtap-tas -o name 2>  /dev/null| grep tuf)
-if [[ $RT == "" ]]; then 
-    export TUF_MIRROR='' 
+RT=$(oc get routes -n rhtap-tas -o name 2> /dev/null | grep tuf)
+if [[ $RT == "" ]]; then
+    export TUF_MIRROR=''
 else
     HOST=$(oc get -n rhtap-tas $RT -o jsonpath={.spec.host})
     export TUF_MIRROR=https://$HOST
-fi 
-
+fi
 
 echo "REKOR_HOST set to $REKOR_HOST"
 echo "TUF_MIRROR set to $TUF_MIRROR"


### PR DESCRIPTION
This pr updates the ci-test script to compute the rekor and tuf endpoint.
ci-test can be used to test all three (jenkins, github actions and gitlab) with the same script.

TODO - ci-test currently requires you update the gitlab and github runner image prior and and jenkins repo manually. Then you run ci-test and it updates the forks with new pipeline content. It was done this way to allow testing ci by runing this once and just updating the jenkins lib and / or images but can be error prone if you forget.
