### PR TITLE
Jenkins: install another missing script

### DIFF
--- a/rhtap.groovy
+++ b/rhtap.groovy
@@ -26,6 +26,11 @@ def run_script (scriptname) {
       install_script ('att-predicate-jenkins.sh')
     }
 
+    if (scriptname == 'gather-images-to-upload-sbom.sh') {
+      // Called from gather-images-to-upload-sbom.sh
+      install_script ('gather-deploy-images.sh')
+    }
+
     install_script (scriptname)
     sh "rhtap/${scriptname}"
 }

--- a/templates/rhtap.groovy.njk
+++ b/templates/rhtap.groovy.njk
@@ -26,6 +26,11 @@ def run_script (scriptname) {
       install_script ('att-predicate-jenkins.sh')
     }
 
+    if (scriptname == 'gather-images-to-upload-sbom.sh') {
+      // Called from gather-images-to-upload-sbom.sh
+      install_script ('gather-deploy-images.sh')
+    }
+
     install_script (scriptname)
     sh "rhtap/${scriptname}"
 }


### PR DESCRIPTION
The gather-images-to-upload-sbom.sh script depends on gather-deploy-images.sh, but the latter wasn't getting installed explicitly.

The pipeline does work, because the gather-deploy-images.sh script coincidentally gets installed by an earlier step in the pipeline. But make sure to install it explicitly to avoid future problems.