### PR TITLE
Run steps sequentially in GitLab by default

### DIFF
--- a/templates/data.yaml
+++ b/templates/data.yaml
@@ -6,10 +6,12 @@ build_steps:
     substeps: [buildah-rhtap, cosign-sign-attest]
   - name: scan
     substeps: [acs-deploy-check, acs-image-check, acs-image-scan]
+    concurrent: true
   - name: deploy
     substeps: [update-deployment]
   - name: summary
     substeps: [show-sbom-rhdh, summary]
+    concurrent: true
 
 build_secrets:
   - name: ROX_API_TOKEN

--- a/templates/gitops-template/.gitlab-ci.yml.njk
+++ b/templates/gitops-template/.gitlab-ci.yml.njk
@@ -15,13 +15,10 @@ stages:
 
 {{ substep }}:
   stage: {{ step.name }}
-  {#- By default they run in parallel but these can't -#}
-  {#- Todo: This should probably be represented in data.yaml -#}
-  {%- if substep == "verify-enterprise-contract" %}
-  needs: [gather-deploy-images]
-  {%- elif substep == "download-sbom-from-url-in-attestation" %}
-  needs: [gather-images-to-upload-sbom]
-  {%- endif %}
+  {% if not step.concurrent and not loop.first -%}
+  {# Make the steps run sequentially -#}
+  needs: [{{ step.substeps[loop.index0 - 1] }}]
+  {% endif -%}
   script:
     - echo "{{ substep }}"
     - bash /work/rhtap/{{ substep }}.sh

--- a/templates/source-repo/.gitlab-ci.yml.njk
+++ b/templates/source-repo/.gitlab-ci.yml.njk
@@ -15,11 +15,10 @@ stages:
 
 {{ substep }}:
   stage: {{ step.name }}
-  {#- By default they run in parallel but this one can't -#}
-  {#- Todo: This should probably be represented in data.yaml -#}
-  {%- if substep == "cosign-sign-attest" %}
-  needs: [buildah-rhtap]
-  {%- endif %}
+  {% if not step.concurrent and not loop.first -%}
+  {# Make the steps run sequentially -#}
+  needs: [{{ step.substeps[loop.index0 - 1] }}]
+  {% endif -%}
   script:
     - echo "{{ substep }}"
     - bash /work/rhtap/{{ substep }}.sh


### PR DESCRIPTION
In some cases we need to ensure tasks run sequentially, but setting the "concurrent" field lets them run in parallel like they do now.

Note that currently GitLab is the only CI type that runs the steps in parallel when "concurrent" is set. Making Jenkins and GitHub behave that way too is something for the future.