### PR TITLE
Use runner image for GitHub

### DIFF
--- a/generated/source-repo/githubactions/.github/workflows/build-and-update-gitops.yml
+++ b/generated/source-repo/githubactions/.github/workflows/build-and-update-gitops.yml
@@ -9,7 +9,6 @@
 name: TSSC-Build-Attest-Scan-Deploy
 env:
   CI_TYPE: github
-
   # 🖊️ EDIT to change the image registry settings.
   # Registries such as GHCR, Quay.io, and Docker Hub are supported.
   IMAGE_REGISTRY: ${{ secrets.IMAGE_REGISTRY }}
@@ -39,6 +38,9 @@ jobs:
     name: Build and send Image Update PR
     # ubuntu-20.04 can also be used.
     runs-on: ubuntu-24.04
+    container:
+      image: quay.io/redhat-appstudio/dance-bootstrap-app:rhtap-runner-github
+      options: --privileged
     environment: production
 
     steps:
@@ -87,43 +89,44 @@ jobs:
       with:
         fetch-depth: '2'
     - name: Pre-init
-      run: | 
-        echo "Using quay.io/redhat-appstudio/dance-bootstrap-app:rhtap-runner"
-        mkdir -p out
-        docker run -v $(pwd)/out:/out quay.io/redhat-appstudio/dance-bootstrap-app:rhtap-runner bash /work/copy-scripts.sh
-        tree out 
-        sudo chmod +x out/binaries/*
-        sudo mv out/binaries/* /usr/bin
-        cp out/rhtap/* rhtap
-        cat  rhtap/env.sh 
+      run: |
+        buildah --version
         syft --version
         cosign version
-        buildah --version
         ec version
     - name: Init
       run: |
         echo "Init"
-        bash rhtap/init.sh
+        echo "init"
+        bash /work/rhtap/init.sh
     - name: Build
       run: |
         echo "Build"
-        bash rhtap/buildah-rhtap.sh
-        bash rhtap/cosign-sign-attest.sh
+        echo "buildah-rhtap"
+        bash /work/rhtap/buildah-rhtap.sh
+        echo "cosign-sign-attest"
+        bash /work/rhtap/cosign-sign-attest.sh
     - name: Scan
       run: |
         echo "Scan"
-        bash rhtap/acs-deploy-check.sh
-        bash rhtap/acs-image-check.sh
-        bash rhtap/acs-image-scan.sh
+        echo "acs-deploy-check"
+        bash /work/rhtap/acs-deploy-check.sh
+        echo "acs-image-check"
+        bash /work/rhtap/acs-image-check.sh
+        echo "acs-image-scan"
+        bash /work/rhtap/acs-image-scan.sh
     - name: Deploy
       run: |
         echo "Deploy"
-        bash rhtap/update-deployment.sh
+        echo "update-deployment"
+        bash /work/rhtap/update-deployment.sh
     - name: Summary
       run: |
         echo "Summary"
-        bash rhtap/show-sbom-rhdh.sh
-        bash rhtap/summary.sh
+        echo "show-sbom-rhdh"
+        bash /work/rhtap/show-sbom-rhdh.sh
+        echo "summary"
+        bash /work/rhtap/summary.sh
     - name: Done
       run: |
         echo "Done"

--- a/templates/source-repo/build-and-update-gitops.yml.njk
+++ b/templates/source-repo/build-and-update-gitops.yml.njk
@@ -8,11 +8,11 @@
 
 name: TSSC-Build-Attest-Scan-Deploy
 env:
+  CI_TYPE: github
+
   {#-
     Todo: Use the secret list in data/data.yaml here
   #}
-  CI_TYPE: github
-
   # 🖊️ EDIT to change the image registry settings.
   # Registries such as GHCR, Quay.io, and Docker Hub are supported.
   IMAGE_REGISTRY: ${{ "secrets.IMAGE_REGISTRY" | inCurlies }}
@@ -42,6 +42,9 @@ jobs:
     name: Build and send Image Update PR
     # ubuntu-20.04 can also be used.
     runs-on: ubuntu-24.04
+    container:
+      image: quay.io/redhat-appstudio/dance-bootstrap-app:rhtap-runner-github
+      options: --privileged
     environment: production
 
     steps:
@@ -93,26 +96,19 @@ jobs:
       with:
         fetch-depth: '2'
     - name: Pre-init
-      run: | 
-        echo "Using quay.io/redhat-appstudio/dance-bootstrap-app:rhtap-runner"
-        mkdir -p out
-        docker run -v $(pwd)/out:/out quay.io/redhat-appstudio/dance-bootstrap-app:rhtap-runner bash /work/copy-scripts.sh
-        tree out 
-        sudo chmod +x out/binaries/*
-        sudo mv out/binaries/* /usr/bin
-        cp out/rhtap/* rhtap
-        cat  rhtap/env.sh 
+      run: |
+        buildah --version
         syft --version
         cosign version
-        buildah --version
-        ec version 
+        ec version
 
 {%- for step in build_steps %}
     - name: {{ step.name | title }}
       run: |
         echo "{{ step.name | title }}"
 {%- for substep in step.substeps %}
-        bash rhtap/{{ substep }}.sh
+        echo "{{ substep }}"
+        bash /work/rhtap/{{ substep }}.sh
 {%- endfor -%}
 {%- endfor %}
     - name: Done


### PR DESCRIPTION
The main issue with running a container on GitHub Actions seems to be with the default AppArmor profile configured -- it does not allow user namespaces needed by buildah.

Another characteristic of GitHub Actions is that the container configured for a Workflow job is used for all steps, so we can't run a command on the host to enable user namespaces. So running something like:

    sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0

is not possible.

This resorts to running the container with extended privileges in order to allow user namespaces.

Resolves: https://issues.redhat.com/browse/RHTAP-3066

Followup to #16