### PR TITLE
Revert "Use runner image for GitHub"

### DIFF
--- a/generated/source-repo/githubactions/.github/workflows/build-and-update-gitops.yml
+++ b/generated/source-repo/githubactions/.github/workflows/build-and-update-gitops.yml
@@ -9,6 +9,7 @@
 name: TSSC-Build-Attest-Scan-Deploy
 env:
   CI_TYPE: github
+
   # 🖊️ EDIT to change the image registry settings.
   # Registries such as GHCR, Quay.io, and Docker Hub are supported.
   IMAGE_REGISTRY: ${{ secrets.IMAGE_REGISTRY }}
@@ -38,9 +39,6 @@ jobs:
     name: Build and send Image Update PR
     # ubuntu-20.04 can also be used.
     runs-on: ubuntu-24.04
-    container:
-      image: quay.io/redhat-appstudio/dance-bootstrap-app:rhtap-runner-github
-      options: --privileged
     environment: production
 
     steps:
@@ -89,44 +87,43 @@ jobs:
       with:
         fetch-depth: '2'
     - name: Pre-init
-      run: |
-        buildah --version
+      run: | 
+        echo "Using quay.io/redhat-appstudio/dance-bootstrap-app:rhtap-runner"
+        mkdir -p out
+        docker run -v $(pwd)/out:/out quay.io/redhat-appstudio/dance-bootstrap-app:rhtap-runner bash /work/copy-scripts.sh
+        tree out 
+        sudo chmod +x out/binaries/*
+        sudo mv out/binaries/* /usr/bin
+        cp out/rhtap/* rhtap
+        cat  rhtap/env.sh 
         syft --version
         cosign version
+        buildah --version
         ec version
     - name: Init
       run: |
         echo "Init"
-        echo "init"
-        bash /work/rhtap/init.sh
+        bash rhtap/init.sh
     - name: Build
       run: |
         echo "Build"
-        echo "buildah-rhtap"
-        bash /work/rhtap/buildah-rhtap.sh
-        echo "cosign-sign-attest"
-        bash /work/rhtap/cosign-sign-attest.sh
+        bash rhtap/buildah-rhtap.sh
+        bash rhtap/cosign-sign-attest.sh
     - name: Scan
       run: |
         echo "Scan"
-        echo "acs-deploy-check"
-        bash /work/rhtap/acs-deploy-check.sh
-        echo "acs-image-check"
-        bash /work/rhtap/acs-image-check.sh
-        echo "acs-image-scan"
-        bash /work/rhtap/acs-image-scan.sh
+        bash rhtap/acs-deploy-check.sh
+        bash rhtap/acs-image-check.sh
+        bash rhtap/acs-image-scan.sh
     - name: Deploy
       run: |
         echo "Deploy"
-        echo "update-deployment"
-        bash /work/rhtap/update-deployment.sh
+        bash rhtap/update-deployment.sh
     - name: Summary
       run: |
         echo "Summary"
-        echo "show-sbom-rhdh"
-        bash /work/rhtap/show-sbom-rhdh.sh
-        echo "summary"
-        bash /work/rhtap/summary.sh
+        bash rhtap/show-sbom-rhdh.sh
+        bash rhtap/summary.sh
     - name: Done
       run: |
         echo "Done"

--- a/templates/source-repo/build-and-update-gitops.yml.njk
+++ b/templates/source-repo/build-and-update-gitops.yml.njk
@@ -8,11 +8,11 @@
 
 name: TSSC-Build-Attest-Scan-Deploy
 env:
-  CI_TYPE: github
-
   {#-
     Todo: Use the secret list in data/data.yaml here
   #}
+  CI_TYPE: github
+
   # 🖊️ EDIT to change the image registry settings.
   # Registries such as GHCR, Quay.io, and Docker Hub are supported.
   IMAGE_REGISTRY: ${{ "secrets.IMAGE_REGISTRY" | inCurlies }}
@@ -42,9 +42,6 @@ jobs:
     name: Build and send Image Update PR
     # ubuntu-20.04 can also be used.
     runs-on: ubuntu-24.04
-    container:
-      image: quay.io/redhat-appstudio/dance-bootstrap-app:rhtap-runner-github
-      options: --privileged
     environment: production
 
     steps:
@@ -96,19 +93,26 @@ jobs:
       with:
         fetch-depth: '2'
     - name: Pre-init
-      run: |
-        buildah --version
+      run: | 
+        echo "Using quay.io/redhat-appstudio/dance-bootstrap-app:rhtap-runner"
+        mkdir -p out
+        docker run -v $(pwd)/out:/out quay.io/redhat-appstudio/dance-bootstrap-app:rhtap-runner bash /work/copy-scripts.sh
+        tree out 
+        sudo chmod +x out/binaries/*
+        sudo mv out/binaries/* /usr/bin
+        cp out/rhtap/* rhtap
+        cat  rhtap/env.sh 
         syft --version
         cosign version
-        ec version
+        buildah --version
+        ec version 
 
 {%- for step in build_steps %}
     - name: {{ step.name | title }}
       run: |
         echo "{{ step.name | title }}"
 {%- for substep in step.substeps %}
-        echo "{{ substep }}"
-        bash /work/rhtap/{{ substep }}.sh
+        bash rhtap/{{ substep }}.sh
 {%- endfor -%}
 {%- endfor %}
     - name: Done


### PR DESCRIPTION
Need to figure out how to avoid these errors:

  fatal: detected dubious ownership in repository at '/__w/rhtap-ci-tester/rhtap-ci-tester'
  To add an exception for this directory, call:
    git config --global --add safe.directory /__w/rhtap-ci-tester/rhtap-ci-tester

This reverts commit 7697a6d73d143bd18b84886470fddc356814aab5.