### PR TITLE
Use runner image for GitHub promote pipeline also

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,4 @@ WORKDIR /work
 
 COPY ./rhtap ./rhtap/
 
-# This is for the GitHub pipeline where currently we're not actually
-# running in the container. Instead we copy the scripts and binaries
-# from the image and run them directly. (This may change in future.)
-COPY copy-scripts.sh /work/copy-scripts.sh
-RUN chmod 755 /work/copy-scripts.sh
-
 CMD ["/bin/bash"]

--- a/Makefile
+++ b/Makefile
@@ -154,9 +154,6 @@ endef
 .PHONY: push-image
 push-image:
 	podman push $(unique-tag)
-	# Two extra tags for backwards compability
-	podman push $(floating-tag)-gitlab
-	podman push $(floating-tag)-github
 	podman push $(floating-tag)
 	@echo Pushed to https://quay.io/repository/$(RUNNER_IMAGE_ORG)/$(RUNNER_IMAGE_REPO)?tab=tags
 
@@ -164,9 +161,6 @@ push-image:
 build-image:
 	podman build $(if $(NOCACHE),--no-cache) -f Dockerfile -t $(floating-tag)
 	podman tag $(floating-tag) $(unique-tag)
-	# Two extra tags for backwards compability
-	podman tag $(floating-tag) $(floating-tag)-gitlab
-	podman tag $(floating-tag) $(floating-tag)-github
 
 .PHONY: run-image
 run-image:

--- a/copy-scripts.sh
+++ b/copy-scripts.sh
@@ -1,8 +1,0 @@
-echo "Copy scripts"
-cp -r /work/rhtap /out/rhtap
-mkdir -p /out/binaries
-for binary in yq cosign ec syft; do
-    echo "binary $binary"
-    cp /usr/bin/$binary /out/binaries/$binary
-    chmod +x /out/binaries/$binary
-done

--- a/generated/gitops-template/githubactions/.github/workflows/gitops-promotion.yml
+++ b/generated/gitops-template/githubactions/.github/workflows/gitops-promotion.yml
@@ -39,6 +39,8 @@ jobs:
     name: Build and send Image Update PR
     # ubuntu-20.04 can also be used.
     runs-on: ubuntu-24.04
+    container:
+      image: quay.io/redhat-appstudio/dance-bootstrap-app:rhtap-runner
     environment: production
 
     steps:
@@ -87,29 +89,26 @@ jobs:
       with:
         fetch-depth: '2'
     - name: Pre-init
-      run: | 
-        echo "Using quay.io/redhat-appstudio/dance-bootstrap-app:rhtap-runner"
-        mkdir -p out
-        docker run -v $(pwd)/out:/out quay.io/redhat-appstudio/dance-bootstrap-app:rhtap-runner bash /work/copy-scripts.sh
-        tree out 
-        sudo chmod +x out/binaries/*
-        sudo mv out/binaries/* /usr/bin
-        cp out/rhtap/* rhtap
-        cat  rhtap/env.sh 
+      run: |
+        buildah --version
         syft --version
         cosign version
-        buildah --version
         ec version
+        git config --global --add safe.directory $(pwd)
     - name: Verify Ec
       run: |
         echo "Verify Ec"
-        bash rhtap/gather-deploy-images.sh
-        bash rhtap/verify-enterprise-contract.sh
+        echo "gather-deploy-images"
+        bash /work/rhtap/gather-deploy-images.sh
+        echo "verify-enterprise-contract"
+        bash /work/rhtap/verify-enterprise-contract.sh
     - name: Upload Sbom
       run: |
         echo "Upload Sbom"
-        bash rhtap/gather-images-to-upload-sbom.sh
-        bash rhtap/download-sbom-from-url-in-attestation.sh
+        echo "gather-images-to-upload-sbom"
+        bash /work/rhtap/gather-images-to-upload-sbom.sh
+        echo "download-sbom-from-url-in-attestation"
+        bash /work/rhtap/download-sbom-from-url-in-attestation.sh
     - name: Done
       run: |
         echo "Done"

--- a/generated/gitops-template/githubactions/.github/workflows/gitops-promotion.yml
+++ b/generated/gitops-template/githubactions/.github/workflows/gitops-promotion.yml
@@ -97,17 +97,15 @@ jobs:
         git config --global --add safe.directory $(pwd)
     - name: Verify Ec
       run: |
-        echo "Verify Ec"
-        echo "gather-deploy-images"
+        echo "• gather-deploy-images"
         bash /work/rhtap/gather-deploy-images.sh
-        echo "verify-enterprise-contract"
+        echo "• verify-enterprise-contract"
         bash /work/rhtap/verify-enterprise-contract.sh
     - name: Upload Sbom
       run: |
-        echo "Upload Sbom"
-        echo "gather-images-to-upload-sbom"
+        echo "• gather-images-to-upload-sbom"
         bash /work/rhtap/gather-images-to-upload-sbom.sh
-        echo "download-sbom-from-url-in-attestation"
+        echo "• download-sbom-from-url-in-attestation"
         bash /work/rhtap/download-sbom-from-url-in-attestation.sh
     - name: Done
       run: |

--- a/generated/gitops-template/githubactions/.github/workflows/gitops-promotion.yml
+++ b/generated/gitops-template/githubactions/.github/workflows/gitops-promotion.yml
@@ -95,6 +95,7 @@ jobs:
         cosign version
         ec version
         git config --global --add safe.directory $(pwd)
+        cat rhtap/env.sh
     - name: Verify Ec
       run: |
         echo "• gather-deploy-images"

--- a/generated/gitops-template/gitlabci/.gitlab-ci.yml
+++ b/generated/gitops-template/gitlabci/.gitlab-ci.yml
@@ -12,7 +12,7 @@ stages:
 gather-deploy-images:
   stage: Verify EC
   script:
-    - echo "gather-deploy-images"
+    - echo "• gather-deploy-images"
     - bash /work/rhtap/gather-deploy-images.sh
   artifacts:
     paths:
@@ -24,7 +24,7 @@ verify-enterprise-contract:
   stage: Verify EC
   needs: [gather-deploy-images]
   script:
-    - echo "verify-enterprise-contract"
+    - echo "• verify-enterprise-contract"
     - bash /work/rhtap/verify-enterprise-contract.sh
   artifacts:
     paths:
@@ -35,7 +35,7 @@ verify-enterprise-contract:
 gather-images-to-upload-sbom:
   stage: Upload SBOM
   script:
-    - echo "gather-images-to-upload-sbom"
+    - echo "• gather-images-to-upload-sbom"
     - bash /work/rhtap/gather-images-to-upload-sbom.sh
   artifacts:
     paths:
@@ -47,7 +47,7 @@ download-sbom-from-url-in-attestation:
   stage: Upload SBOM
   needs: [gather-images-to-upload-sbom]
   script:
-    - echo "download-sbom-from-url-in-attestation"
+    - echo "• download-sbom-from-url-in-attestation"
     - bash /work/rhtap/download-sbom-from-url-in-attestation.sh
   artifacts:
     paths:

--- a/generated/source-repo/githubactions/.github/workflows/build-and-update-gitops.yml
+++ b/generated/source-repo/githubactions/.github/workflows/build-and-update-gitops.yml
@@ -98,36 +98,31 @@ jobs:
         git config --global --add safe.directory $(pwd)
     - name: Init
       run: |
-        echo "Init"
-        echo "init"
+        echo "• init"
         bash /work/rhtap/init.sh
     - name: Build
       run: |
-        echo "Build"
-        echo "buildah-rhtap"
+        echo "• buildah-rhtap"
         bash /work/rhtap/buildah-rhtap.sh
-        echo "cosign-sign-attest"
+        echo "• cosign-sign-attest"
         bash /work/rhtap/cosign-sign-attest.sh
     - name: Scan
       run: |
-        echo "Scan"
-        echo "acs-deploy-check"
+        echo "• acs-deploy-check"
         bash /work/rhtap/acs-deploy-check.sh
-        echo "acs-image-check"
+        echo "• acs-image-check"
         bash /work/rhtap/acs-image-check.sh
-        echo "acs-image-scan"
+        echo "• acs-image-scan"
         bash /work/rhtap/acs-image-scan.sh
     - name: Deploy
       run: |
-        echo "Deploy"
-        echo "update-deployment"
+        echo "• update-deployment"
         bash /work/rhtap/update-deployment.sh
     - name: Summary
       run: |
-        echo "Summary"
-        echo "show-sbom-rhdh"
+        echo "• show-sbom-rhdh"
         bash /work/rhtap/show-sbom-rhdh.sh
-        echo "summary"
+        echo "• summary"
         bash /work/rhtap/summary.sh
     - name: Done
       run: |

--- a/generated/source-repo/githubactions/.github/workflows/build-and-update-gitops.yml
+++ b/generated/source-repo/githubactions/.github/workflows/build-and-update-gitops.yml
@@ -96,6 +96,7 @@ jobs:
         cosign version
         ec version
         git config --global --add safe.directory $(pwd)
+        cat rhtap/env.sh
     - name: Init
       run: |
         echo "• init"

--- a/generated/source-repo/gitlabci/.gitlab-ci.yml
+++ b/generated/source-repo/gitlabci/.gitlab-ci.yml
@@ -15,7 +15,7 @@ stages:
 init:
   stage: init
   script:
-    - echo "init"
+    - echo "• init"
     - bash /work/rhtap/init.sh
   artifacts:
     paths:
@@ -24,7 +24,7 @@ init:
 buildah-rhtap:
   stage: build
   script:
-    - echo "buildah-rhtap"
+    - echo "• buildah-rhtap"
     - bash /work/rhtap/buildah-rhtap.sh
   artifacts:
     paths:
@@ -34,7 +34,7 @@ cosign-sign-attest:
   stage: build
   needs: [buildah-rhtap]
   script:
-    - echo "cosign-sign-attest"
+    - echo "• cosign-sign-attest"
     - bash /work/rhtap/cosign-sign-attest.sh
   artifacts:
     paths:
@@ -43,7 +43,7 @@ cosign-sign-attest:
 acs-deploy-check:
   stage: scan
   script:
-    - echo "acs-deploy-check"
+    - echo "• acs-deploy-check"
     - bash /work/rhtap/acs-deploy-check.sh
   artifacts:
     paths:
@@ -52,7 +52,7 @@ acs-deploy-check:
 acs-image-check:
   stage: scan
   script:
-    - echo "acs-image-check"
+    - echo "• acs-image-check"
     - bash /work/rhtap/acs-image-check.sh
   artifacts:
     paths:
@@ -61,7 +61,7 @@ acs-image-check:
 acs-image-scan:
   stage: scan
   script:
-    - echo "acs-image-scan"
+    - echo "• acs-image-scan"
     - bash /work/rhtap/acs-image-scan.sh
   artifacts:
     paths:
@@ -70,7 +70,7 @@ acs-image-scan:
 update-deployment:
   stage: deploy
   script:
-    - echo "update-deployment"
+    - echo "• update-deployment"
     - bash /work/rhtap/update-deployment.sh
   artifacts:
     paths:
@@ -81,7 +81,7 @@ update-deployment:
 show-sbom-rhdh:
   stage: summary
   script:
-    - echo "show-sbom-rhdh"
+    - echo "• show-sbom-rhdh"
     - bash /work/rhtap/show-sbom-rhdh.sh
   artifacts:
     paths:
@@ -90,7 +90,7 @@ show-sbom-rhdh:
 summary:
   stage: summary
   script:
-    - echo "summary"
+    - echo "• summary"
     - bash /work/rhtap/summary.sh
   artifacts:
     paths:

--- a/templates/gitops-template/.gitlab-ci.yml.njk
+++ b/templates/gitops-template/.gitlab-ci.yml.njk
@@ -20,7 +20,7 @@ stages:
   needs: [{{ step.substeps[loop.index0 - 1] }}]
   {% endif -%}
   script:
-    - echo "{{ substep }}"
+    - echo "• {{ substep }}"
     - bash /work/rhtap/{{ substep }}.sh
   artifacts:
     paths:

--- a/templates/gitops-template/gitops-promotion.yml.njk
+++ b/templates/gitops-template/gitops-promotion.yml.njk
@@ -102,6 +102,7 @@ jobs:
         ec version
         {# So git doesn't throw "dubious ownership" errors -#}
         git config --global --add safe.directory $(pwd)
+        cat rhtap/env.sh
 
 {%- for step in gitops_steps %}
     - name: {{ step.name | title }}

--- a/templates/gitops-template/gitops-promotion.yml.njk
+++ b/templates/gitops-template/gitops-promotion.yml.njk
@@ -42,6 +42,8 @@ jobs:
     name: Build and send Image Update PR
     # ubuntu-20.04 can also be used.
     runs-on: ubuntu-24.04
+    container:
+      image: quay.io/redhat-appstudio/dance-bootstrap-app:rhtap-runner
     environment: production
 
     steps:
@@ -93,26 +95,21 @@ jobs:
       with:
         fetch-depth: '2'
     - name: Pre-init
-      run: | 
-        echo "Using quay.io/redhat-appstudio/dance-bootstrap-app:rhtap-runner"
-        mkdir -p out
-        docker run -v $(pwd)/out:/out quay.io/redhat-appstudio/dance-bootstrap-app:rhtap-runner bash /work/copy-scripts.sh
-        tree out 
-        sudo chmod +x out/binaries/*
-        sudo mv out/binaries/* /usr/bin
-        cp out/rhtap/* rhtap
-        cat  rhtap/env.sh 
+      run: |
+        buildah --version
         syft --version
         cosign version
-        buildah --version
-        ec version 
+        ec version
+        {# So git doesn't throw "dubious ownership" errors -#}
+        git config --global --add safe.directory $(pwd)
 
 {%- for step in gitops_steps %}
     - name: {{ step.name | title }}
       run: |
         echo "{{ step.name | title }}"
 {%- for substep in step.substeps %}
-        bash rhtap/{{ substep }}.sh
+        echo "{{ substep }}"
+        bash /work/rhtap/{{ substep }}.sh
 {%- endfor -%}
 {%- endfor %}
     - name: Done

--- a/templates/gitops-template/gitops-promotion.yml.njk
+++ b/templates/gitops-template/gitops-promotion.yml.njk
@@ -106,9 +106,8 @@ jobs:
 {%- for step in gitops_steps %}
     - name: {{ step.name | title }}
       run: |
-        echo "{{ step.name | title }}"
 {%- for substep in step.substeps %}
-        echo "{{ substep }}"
+        echo "• {{ substep }}"
         bash /work/rhtap/{{ substep }}.sh
 {%- endfor -%}
 {%- endfor %}

--- a/templates/source-repo/.gitlab-ci.yml.njk
+++ b/templates/source-repo/.gitlab-ci.yml.njk
@@ -20,7 +20,7 @@ stages:
   needs: [{{ step.substeps[loop.index0 - 1] }}]
   {% endif -%}
   script:
-    - echo "{{ substep }}"
+    - echo "• {{ substep }}"
     - bash /work/rhtap/{{ substep }}.sh
   artifacts:
     paths:

--- a/templates/source-repo/build-and-update-gitops.yml.njk
+++ b/templates/source-repo/build-and-update-gitops.yml.njk
@@ -107,9 +107,8 @@ jobs:
 {%- for step in build_steps %}
     - name: {{ step.name | title }}
       run: |
-        echo "{{ step.name | title }}"
 {%- for substep in step.substeps %}
-        echo "{{ substep }}"
+        echo "• {{ substep }}"
         bash /work/rhtap/{{ substep }}.sh
 {%- endfor -%}
 {%- endfor %}

--- a/templates/source-repo/build-and-update-gitops.yml.njk
+++ b/templates/source-repo/build-and-update-gitops.yml.njk
@@ -103,6 +103,7 @@ jobs:
         ec version
         {# So git doesn't throw "dubious ownership" errors -#}
         git config --global --add safe.directory $(pwd)
+        cat rhtap/env.sh
 
 {%- for step in build_steps %}
     - name: {{ step.name | title }}


### PR DESCRIPTION
In #58 we changed the GitHub build pipeline to use the docker runner image. This PR changes the promote pipeline similarly.

There are some additional cleanups and tweaks, see commits for details.

Ref: https://issues.redhat.com/browse/RHTAP-3066