### PR TITLE
Refined Jenkins build attestation

### DIFF
--- a/generated/gitops-template/jenkins/Jenkinsfile
+++ b/generated/gitops-template/jenkins/Jenkinsfile
@@ -1,9 +1,5 @@
 /* Generated from templates/gitops-template/Jenkinsfile.njk. Do not edit directly. */
 
-library identifier: 'RHTAP_Jenkins@main', retriever: modernSCM(
-  [$class: 'GitSCMSource',
-   remote: 'https://github.com/redhat-appstudio/tssc-sample-jenkins.git'])
-
 pipeline {
     agent any
     environment {

--- a/generated/source-repo/jenkins/Jenkinsfile
+++ b/generated/source-repo/jenkins/Jenkinsfile
@@ -1,9 +1,5 @@
 /* Generated from templates/source-repo/Jenkinsfile.njk. Do not edit directly. */
 
-library identifier: 'RHTAP_Jenkins@main', retriever: modernSCM(
-  [$class: 'GitSCMSource',
-   remote: 'https://github.com/redhat-appstudio/tssc-sample-jenkins.git'])
-
 pipeline {
     agent any
     environment {
@@ -16,6 +12,9 @@ pipeline {
         COSIGN_SECRET_PASSWORD = credentials('COSIGN_SECRET_PASSWORD')
         COSIGN_SECRET_KEY = credentials('COSIGN_SECRET_KEY')
         COSIGN_PUBLIC_KEY = credentials('COSIGN_PUBLIC_KEY')
+        PIPELINE_PATH = "${rhtap.env().pipeline_path}"
+        RUN_CAUSES = "${rhtap.env().run_causes}"
+        START_TIME = "${rhtap.env().start_time}"
     }
     stages {
         stage('init') {

--- a/rhtap.groovy
+++ b/rhtap.groovy
@@ -1,5 +1,9 @@
 /* Generated from templates/rhtap.groovy.njk. Do not edit directly. */
 
+import groovy.json.*
+import java.time.*
+import java.time.format.*
+
 def info(message) {
     echo "INFO: ${message}"
 }
@@ -85,4 +89,12 @@ def gather_images_to_upload_sbom( ) {
 
 def download_sbom_from_url_in_attestation( ) {
     run_script ('download-sbom-from-url-in-attestation.sh')
+}
+
+def env() {
+    [
+        pipeline_path: currentBuild.rawBuild.parent.definition.scriptPath,
+        run_causes: JsonOutput.toJson(currentBuild.rawBuild.causes.collect { it.shortDescription }),
+        start_time: DateTimeFormatter.ISO_INSTANT.format(Instant.ofEpochMilli(currentBuild.rawBuild.startTimeInMillis)),
+    ]
 }

--- a/rhtap/att-predicate-jenkins.sh
+++ b/rhtap/att-predicate-jenkins.sh
@@ -11,8 +11,20 @@ yq -o=json -I=0 << EOT
 ---
 buildDefinition:
   buildType: "https://redhat.com/rhtap/slsa-build-types/${CI_TYPE}-build/v1"
-  externalParameters: {}
-  internalParameters: {}
+  externalParameters:
+    pipeline:
+      ref: "${GIT_COMMIT}"
+      repository: "${GIT_URL}"
+      path: "${PIPELINE_PATH}"
+  internalParameters:
+    jenkins:
+      run_causes: "${RUN_CAUSES}"
+      job_name: "${JOB_NAME}"
+      node_labels: "${NODE_LABELS}"
+      build_number: "${BUILD_NUMBER}"
+      executor_number: "${EXECUTOR_NUMBER}"
+      build_url: "${BUILD_URL}"
+      job_url: "${JOB_URL}"
   resolvedDependencies:
     - uri: "git+${GIT_URL}"
       digest:
@@ -21,19 +33,10 @@ buildDefinition:
 runDetails:
   builder:
     id: "${NODE_NAME}"
-    builderDependencies: []
-    version:
-      # Not sure if this is the right place for these...
-      buildNumber: "${BUILD_NUMBER}"
-      jobName: "${JOB_NAME}"
-      executorNumber: "${EXECUTOR_NUMBER}"
-      jenkinsHome: "${JENKINS_HOME}"
-      buildUrl: "${BUILD_URL}"
-      jobUrl: "${JOB_URL}"
 
   metadata:
     invocationID: "${BUILD_TAG}"
-    startedOn: "$(cat $BASE_RESULTS/init/START_TIME)"
+    startedOn: "${START_TIME}"
     # Inaccurate, but maybe close enough
     finishedOn: "$(timestamp)"
 

--- a/templates/gitops-template/Jenkinsfile.njk
+++ b/templates/gitops-template/Jenkinsfile.njk
@@ -1,7 +1,5 @@
 {%- include "do-not-edit.njk" -%}
 
-{%- include "jenkins-library-source.njk" -%}
-
 pipeline {
     agent any
     environment {

--- a/templates/partials/jenkins-library-source.njk
+++ b/templates/partials/jenkins-library-source.njk
@@ -1,4 +1,0 @@
-library identifier: 'RHTAP_Jenkins@main', retriever: modernSCM(
-  [$class: 'GitSCMSource',
-   remote: 'https://github.com/redhat-appstudio/tssc-sample-jenkins.git'])
-{{- nlnl -}}

--- a/templates/rhtap.groovy.njk
+++ b/templates/rhtap.groovy.njk
@@ -1,4 +1,7 @@
 {%- include "do-not-edit.njk" -%}
+import groovy.json.*
+import java.time.*
+import java.time.format.*
 
 def info(message) {
     echo "INFO: ${message}"
@@ -43,3 +46,11 @@ def {{ substep | replace("-", "_") }}( ) {
 
 {% endfor -%}
 {%- endfor -%}
+
+def env() {
+    [
+        pipeline_path: currentBuild.rawBuild.parent.definition.scriptPath,
+        run_causes: JsonOutput.toJson(currentBuild.rawBuild.causes.collect { it.shortDescription }),
+        start_time: DateTimeFormatter.ISO_INSTANT.format(Instant.ofEpochMilli(currentBuild.rawBuild.startTimeInMillis)),
+    ]
+}

--- a/templates/source-repo/Jenkinsfile.njk
+++ b/templates/source-repo/Jenkinsfile.njk
@@ -1,13 +1,14 @@
 {%- include "do-not-edit.njk" -%}
 
-{%- include "jenkins-library-source.njk" -%}
-
 pipeline {
     agent any
     environment {
         {%- for secret in build_secrets -%}
         {%- include "jenkins-secret.njk" -%}
         {%- endfor %}
+        PIPELINE_PATH = "${rhtap.env().pipeline_path}"
+        RUN_CAUSES = "${rhtap.env().run_causes}"
+        START_TIME = "${rhtap.env().start_time}"
     }
     stages {
         {%- for step in build_steps %}


### PR DESCRIPTION
Makes the SLSA Provenance attestation produced by RHTAP when running on Jenkins similar to the attestations produced when running on GitLab and GitHub by reshuffling and adding several new properties.

Some of the properties are fetched from Jenkins object graph that is not accessible to the untrusted Pipeline libraries and if run as untrusted will be blocked and require script approval.

As a result of hat the Pipeline library consisting of `rhtap.groovy` in `vars/` directory needs to be installed as a global trusted library[1].

Reference: https://issues.redhat.com/browse/EC-774

[1] https://www.jenkins.io/doc/book/pipeline/shared-libraries/#global-shared-libraries