### PR TITLE
Update two dependencies in the task runner image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN \
   curl -sL https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64 -o /usr/bin/yq && chmod 755 /usr/bin/yq && \
   curl -sL https://github.com/sigstore/cosign/releases/download/v2.4.1/cosign-linux-amd64 -o /usr/bin/cosign && chmod 755 /usr/bin/cosign && \
   curl -sL https://github.com/enterprise-contract/ec-cli/releases/download/v0.6.104/ec_linux_amd64 -o /usr/bin/ec && chmod 755 /usr/bin/ec && \
-  curl -sL https://github.com/anchore/syft/releases/download/v1.14.1/syft_1.14.1_linux_amd64.tar.gz | tar zxf - syft && mv syft /usr/bin/syft
+  curl -sL https://github.com/anchore/syft/releases/download/v1.14.2/syft_1.14.2_linux_amd64.tar.gz | tar zxf - syft && mv syft /usr/bin/syft
 
 WORKDIR /work
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN \
 RUN \
   curl -sL https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64 -o /usr/bin/yq && chmod 755 /usr/bin/yq && \
   curl -sL https://github.com/sigstore/cosign/releases/download/v2.4.1/cosign-linux-amd64 -o /usr/bin/cosign && chmod 755 /usr/bin/cosign && \
-  curl -sL https://github.com/enterprise-contract/ec-cli/releases/download/v0.6.58/ec_linux_amd64 -o /usr/bin/ec && chmod 755 /usr/bin/ec && \
+  curl -sL https://github.com/enterprise-contract/ec-cli/releases/download/v0.6.104/ec_linux_amd64 -o /usr/bin/ec && chmod 755 /usr/bin/ec && \
   curl -sL https://github.com/anchore/syft/releases/download/v1.14.1/syft_1.14.1_linux_amd64.tar.gz | tar zxf - syft && mv syft /usr/bin/syft
 
 WORKDIR /work


### PR DESCRIPTION
Update ec and the syft binaries. The cosign and yq binaries don't need an update.