### PR TITLE
download-sbom: always create SBOMS_DIR

### DIFF
--- a/rhtap/download-sbom-from-url-in-attestation.sh
+++ b/rhtap/download-sbom-from-url-in-attestation.sh
@@ -288,6 +288,9 @@ find_blob_url() {
       end' < "$attestation_file"
 }
 
+echo "Making sure $SBOMS_DIR directory exists"
+mkdir -p "$SBOMS_DIR"
+
 jq -r '.components[].containerImage' <<< "$IMAGES" | while read -r image; do
     echo "Looking for SBOM_BLOB_URL result in the attestation for $image"
     attestation_file="$WORKDIR/$image/attestations.json"


### PR DESCRIPTION
Currently, when there are no SBOMs to download->upload, the pipeline fails because the upload-sbom script runs on a non-existing directory.

Even if there are no SBOMs to download, create an empty SBOMS_DIR. This should serve as an indication for the upload-sbom script that everything ran correctly, but there really are no SBOMs to upload.