### PR TITLE
Fix the runner-image base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Base image for use as a step runner for RHTAP pipelines
 #
 
-FROM docker.io/redhat/ubi9-minimal:9.4
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4
 
 # Todo:
 # - Pin all the versions (maybe)

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Base image for use as a step runner for RHTAP pipelines
 #
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4@sha256:c0e70387664f30cd9cf2795b547e4a9a51002c44a4a86aa9335ab030134bf392
 
 # Todo:
 # - Pin all the versions (maybe)


### PR DESCRIPTION
Pulling from `docker.io` will not be acceptable for releasing via the Red Hat instance of Konflux

Also pin to digest