### PR TITLE
fix github secrets validation

### DIFF
--- a/generated/gitops-template/githubactions/.github/workflows/gitops-promotion.yml
+++ b/generated/gitops-template/githubactions/.github/workflows/gitops-promotion.yml
@@ -26,11 +26,6 @@ env:
   TRUSTIFICATION_OIDC_CLIENT_SECRET: ${{ secrets.TRUSTIFICATION_OIDC_CLIENT_SECRET }}
   TRUSTIFICATION_SUPPORTED_CYCLONEDX_VERSION: ${{ secrets.TRUSTIFICATION_SUPPORTED_CYCLONEDX_VERSION }}
 
-  TRUSTIFICATION_BOMBASTIC_API_URL: ${{ secrets.TRUSTIFICATION_BOMBASTIC_API_URL }}
-  TRUSTIFICATION_OIDC_ISSUER_URL: ${{ secrets.TRUSTIFICATION_OIDC_ISSUER_URL }}
-  TRUSTIFICATION_OIDC_CLIENT_ID: ${{ secrets.TRUSTIFICATION_OIDC_CLIENT_ID }}
-  TRUSTIFICATION_OIDC_CLIENT_SECRET: ${{ secrets.TRUSTIFICATION_OIDC_CLIENT_SECRET }} 
-
   # 🖊️ EDIT to specify custom tags for the container image, or default tags will be generated below.
   IMAGE_TAGS: ""
   IMAGE_TAG: ""
@@ -58,11 +53,8 @@ jobs:
             IMAGE_REGISTRY_USER: `${{ secrets.IMAGE_REGISTRY_USER }}`,
             IMAGE_REGISTRY_PASSWORD: `${{ secrets.IMAGE_REGISTRY_PASSWORD }}`,
 
-            # Used to verify the image signature and attestation
             COSIGN_PUBLIC_KEY: `${{ secrets.COSIGN_PUBLIC_KEY }}`,
-            # URL of the BOMbastic api host (e.g. https://sbom.trustification.dev)
             TRUSTIFICATION_BOMBASTIC_API_URL: `${{ secrets.TRUSTIFICATION_BOMBASTIC_API_URL }}`,
-            # URL of the OIDC token issuer (e.g. https://sso.trustification.dev/realms/chicken)
             TRUSTIFICATION_OIDC_ISSUER_URL: `${{ secrets.TRUSTIFICATION_OIDC_ISSUER_URL }}`,
             TRUSTIFICATION_OIDC_CLIENT_ID: `${{ secrets.TRUSTIFICATION_OIDC_CLIENT_ID }}`,
             TRUSTIFICATION_OIDC_CLIENT_SECRET: `${{ secrets.TRUSTIFICATION_OIDC_CLIENT_SECRET }}`,

--- a/hack/ghub-set-vars
+++ b/hack/ghub-set-vars
@@ -16,7 +16,7 @@ function setVars() {
     VALUE=$2
     echo "setting Secret $NAME in $REPO"
     if [ -z "$VALUE" ]; then
-        gh secret delete "$NAME"
+        gh secret set "$NAME" -b " "
     else
         gh secret set "$NAME" -b "$VALUE"
     fi

--- a/rhtap/upload-sbom-to-trustification.sh
+++ b/rhtap/upload-sbom-to-trustification.sh
@@ -127,7 +127,7 @@ required_vars=(
 )
 any_missing=false
 for env_var in "${required_vars[@]}"; do
-    if [[ -z "${!env_var}" ]]; then
+    if [[ -z "${!env_var// /}" ]]; then
         echo "Missing environment variable: $env_var" >&2
         any_missing=true
     fi

--- a/templates/gitops-template/gitops-promotion.yml.njk
+++ b/templates/gitops-template/gitops-promotion.yml.njk
@@ -24,11 +24,6 @@ env:
 {%- endif %}
 {%- endfor %}
 
-  TRUSTIFICATION_BOMBASTIC_API_URL: ${{ "secrets.TRUSTIFICATION_BOMBASTIC_API_URL" | inCurlies }}
-  TRUSTIFICATION_OIDC_ISSUER_URL: ${{ "secrets.TRUSTIFICATION_OIDC_ISSUER_URL" | inCurlies }}
-  TRUSTIFICATION_OIDC_CLIENT_ID: ${{ "secrets.TRUSTIFICATION_OIDC_CLIENT_ID" | inCurlies }}
-  TRUSTIFICATION_OIDC_CLIENT_SECRET: ${{ "secrets.TRUSTIFICATION_OIDC_CLIENT_SECRET" | inCurlies }} 
-
   # 🖊️ EDIT to specify custom tags for the container image, or default tags will be generated below.
   IMAGE_TAGS: ""
   IMAGE_TAG: ""
@@ -60,9 +55,6 @@ jobs:
             IMAGE_REGISTRY_PASSWORD: `${{ "secrets.IMAGE_REGISTRY_PASSWORD" | inCurlies }}`,
 {% for secret in gitops_secrets %}
 {%- if secret | eval_if_condition %}
-{%- if secret.comment %}
-            # {{ secret.comment }}
-{%- endif %}
             {{ secret.name }}: `${{ ("secrets." + secret.name) | inCurlies }}`,
 {%- endif %}
 {%- endfor %}


### PR DESCRIPTION
- remove comments from githubscripts (they break the scripts) - prior PR added them
- Special Hack: Allow blanks in GHUB secrets for TRUSTIFICATION which enable the CLI to set without prompting the user 