### PR TITLE
Credentials fix for private repos

### DIFF
--- a/hack/wait-for-gitops-update.sh
+++ b/hack/wait-for-gitops-update.sh
@@ -15,7 +15,10 @@ git clone $GITLAB_REPO $GL_LOCAL --quiet
 git clone $JENKINS_REPO $J_LOCAL --quiet
 WATCH=components/tssc-dev/overlays/development/deployment-patch.yaml
 function getImage() {
-    (cd $1; yq .spec.template.spec.containers[0].image $WATCH)
+    (
+        cd $1
+        yq .spec.template.spec.containers[0].image $WATCH
+    )
 }
 
 # Note, the env var name PREV_IMAGE_ENV_NAME is passed so it can be updated
@@ -72,8 +75,11 @@ while true; do
 
     echo "Checking repo contents ..."
     for repo in $GH_LOCAL $GL_LOCAL $J_LOCAL; do
-        (cd $repo; git pull --quiet)
-    done 
+        (
+            cd $repo
+            git pull --quiet
+        )
+    done
     # pass the var name to hold the previus value so it can be updated
     GH_CURRENT=$(getImage $GH_LOCAL)
     promoteIfUpdated GH_PREV $GH_CURRENT $GITHUB_REPO

--- a/hack/wait-for-gitops-update.sh
+++ b/hack/wait-for-gitops-update.sh
@@ -5,12 +5,17 @@ GITHUB_REPO=https://github.com/$MY_GITHUB_USER/tssc-dev-gitops
 GITLAB_REPO=https://gitlab.com/$MY_GITLAB_USER/tssc-dev-gitops
 JENKINS_REPO=https://github.com/$MY_GITHUB_USER/tssc-dev-gitops-jenkins
 
-GH_RAW=https://raw.githubusercontent.com/$MY_GITHUB_USER/tssc-dev-gitops/refs/heads/main/components/tssc-dev/overlays/development/deployment-patch.yaml
-GL_RAW=https://gitlab.com/$MY_GITLAB_USER/tssc-dev-gitops/-/raw/main/components/tssc-dev/overlays/development/deployment-patch.yaml
-J_RAW=https://raw.githubusercontent.com/$MY_GITHUB_USER/tssc-dev-gitops-jenkins/refs/heads/main/components/tssc-dev/overlays/development/deployment-patch.yaml
+WORK=$(mktemp -d)
 
+GH_LOCAL=$WORK/gh-gitops
+GL_LOCAL=$WORK/gl-gitops
+J_LOCAL=$WORK/j-gitops
+git clone $GITHUB_REPO $GH_LOCAL --quiet
+git clone $GITLAB_REPO $GL_LOCAL --quiet
+git clone $JENKINS_REPO $J_LOCAL --quiet
+WATCH=components/tssc-dev/overlays/development/deployment-patch.yaml
 function getImage() {
-    curl -sL $1 | yq .spec.template.spec.containers[0].image
+    (cd $1; yq .spec.template.spec.containers[0].image $WATCH)
 }
 
 # Note, the env var name PREV_IMAGE_ENV_NAME is passed so it can be updated
@@ -45,9 +50,9 @@ function pushIfUpdated() {
     fi
 }
 
-GH_PREV=$(getImage $GH_RAW)
-GL_PREV=$(getImage $GL_RAW)
-J_PREV=$(getImage $J_RAW)
+GH_PREV=$(getImage $GH_LOCAL)
+GL_PREV=$(getImage $GL_LOCAL)
+J_PREV=$(getImage $J_LOCAL)
 # count down and reprint the messages
 COUNT=0
 while true; do
@@ -66,12 +71,15 @@ while true; do
     let COUNT--
 
     echo "Checking repo contents ..."
+    for repo in $GH_LOCAL $GL_LOCAL $J_LOCAL; do
+        (cd $repo; git pull --quiet)
+    done 
     # pass the var name to hold the previus value so it can be updated
-    GH_CURRENT=$(getImage $GH_RAW)
+    GH_CURRENT=$(getImage $GH_LOCAL)
     promoteIfUpdated GH_PREV $GH_CURRENT $GITHUB_REPO
-    GL_CURRENT=$(getImage $GL_RAW)
+    GL_CURRENT=$(getImage $GL_LOCAL)
     promoteIfUpdated GL_PREV $GL_CURRENT $GITLAB_REPO
-    J_CURRENT=$(getImage $J_RAW)
+    J_CURRENT=$(getImage $J_LOCAL)
     pushIfUpdated J_PREV $J_CURRENT $JENKINS_REPO
     SLEEP=10
     echo "Sleep..."

--- a/rhtap/acs-deploy-check.sh
+++ b/rhtap/acs-deploy-check.sh
@@ -38,7 +38,9 @@ function rox-deploy-check() {
         password=$GITOPS_AUTH_PASSWORD
         if [[ -n "$GITOPS_AUTH_USERNAME" ]]; then
             username=$GITOPS_AUTH_USERNAME
-            echo "https://${username}:${password})@${hostname}" > "${HOME}/.git-credentials"
+            hostname=$(echo "${GITOPS_REPO_URL}" | awk -F/ '{print $3}')
+            echo "https://${username}:${password}@${hostname}" > "${HOME}/.git-credentials"
+            printf "[credential \"https://%s\"]\n helper = store" "${hostname}" > "${HOME}/.gitconfig"
             origin_with_auth=https://${username}:${password}@${remote_without_protocol}.git
         else
             origin_with_auth=https://${password}@${remote_without_protocol}.git

--- a/rhtap/buildah-rhtap.sh
+++ b/rhtap/buildah-rhtap.sh
@@ -14,7 +14,7 @@ function build() {
     # Users should set IMAGE_REGISTRY_USER and IMAGE_REGISTRY_PASSWORD from now on
     # For backwards compatibility use the ARTIFACTORY or NEXUS or QUAY creds in place
     # and this code will determine which one to use.
-    if [[ -z "$IMAGE_REGISTRY_USER" || -z "$IMAGE_REGISTRY_PASSWORD" ]]; then 
+    if [[ -z "$IMAGE_REGISTRY_USER" || -z "$IMAGE_REGISTRY_PASSWORD" ]]; then
         # Determine credentials based on the registry
         echo "Using $IMAGE_REGISTRY to determine quay,nexus or artifactory"
         echo "Set IMAGE_REGISTRY_USER and IMAGE_REGISTRY_PASSWORD secrets to override detection"
@@ -28,7 +28,7 @@ function build() {
             IMAGE_REGISTRY_USER="$QUAY_IO_CREDS_USR"
             IMAGE_REGISTRY_PASSWORD="$QUAY_IO_CREDS_PSW"
         fi
-    else 
+    else
         echo "Using IMAGE_REGISTRY_USER and IMAGE_REGISTRY_PASSWORD secrets for buildah"
     fi
     buildah login --username="$IMAGE_REGISTRY_USER" --password="$IMAGE_REGISTRY_PASSWORD" $IMAGE_REGISTRY

--- a/rhtap/cosign-sign-attest.sh
+++ b/rhtap/cosign-sign-attest.sh
@@ -31,7 +31,7 @@ function cosign-login() {
     # Users should set IMAGE_REGISTRY_USER and IMAGE_REGISTRY_PASSWORD for the registri
     # For backwards compatibility use the ARTIFACTORY or NEXUS or QUAY creds in place
     # and this code will determine which one to use.
-    if [[ -z "$IMAGE_REGISTRY_USER" || -z "$IMAGE_REGISTRY_PASSWORD" ]]; then 
+    if [[ -z "$IMAGE_REGISTRY_USER" || -z "$IMAGE_REGISTRY_PASSWORD" ]]; then
         # Determine credentials based on the registry
         echo "Using $image_registry to determine quay,nexus or artifactory"
         echo "Set IMAGE_REGISTRY_USER and IMAGE_REGISTRY_PASSWORD secrets to override detection"
@@ -44,10 +44,10 @@ function cosign-login() {
         else
             IMAGE_REGISTRY_USER="$QUAY_IO_CREDS_USR"
             IMAGE_REGISTRY_PASSWORD="$QUAY_IO_CREDS_PSW"
-        fi 
-    else 
+        fi
+    else
         echo "Using IMAGE_REGISTRY_USER and IMAGE_REGISTRY_PASSWORD secrets for cosign"
-    fi  
+    fi
     cosign login --username="$IMAGE_REGISTRY_USER" --password="$IMAGE_REGISTRY_PASSWORD" "$image_registry"
 }
 

--- a/rhtap/update-deployment.sh
+++ b/rhtap/update-deployment.sh
@@ -24,7 +24,9 @@ function patch-gitops() {
         password=$GITOPS_AUTH_PASSWORD
         if [[ -n "$GITOPS_AUTH_USERNAME" ]]; then
             username=$GITOPS_AUTH_USERNAME
-            echo "https://${username}:${password})@${hostname}" > "${HOME}/.git-credentials"
+            hostname=$(echo "${GITOPS_REPO_URL}" | awk -F/ '{print $3}')
+            echo "https://${username}:${password}@${hostname}" > "${HOME}/.git-credentials"
+            printf "[credential \"https://%s\"]\n helper = store" "${hostname}" > "${HOME}/.gitconfig"
             origin_with_auth=https://${username}:${password}@${remote_without_protocol}.git
         else
             origin_with_auth=https://${password}@${remote_without_protocol}.git


### PR DESCRIPTION

The credentials code to create .git-credentials had errors. This PR fixes those to enable private gitops repos

In testing, I noticed the utility I use to automatically do pull-requests was taking too long due to the "raw" urls being cached --- converted to use repos directly and added to this PR