### PR TITLE
verify ec and sboms from private registry

### DIFF
--- a/build-pipeline.sh
+++ b/build-pipeline.sh
@@ -31,7 +31,7 @@ cp -r rhtap $BUILD/
 # ENV with params
 SETUP_ENV=$BUILD/rhtap/env.sh
 cp rhtap/env.template.sh $SETUP_ENV
-sed -i "s!\${{ values.image }}!quay.io/$MY_QUAY_USER/bootstrap!g" $SETUP_ENV
+sed -i "s!\${{ values.image }}!$IMAGE_TO_BUILD!g" $SETUP_ENV
 sed -i "s!\${{ values.dockerfile }}!Dockerfile!g" $SETUP_ENV
 sed -i "s!\${{ values.buildContext }}!.!g" $SETUP_ENV
 sed -i "s!\${{ values.repoURL }}!$OPTIONAL_REPO_UPDATE!g" $SETUP_ENV

--- a/ci-test.sh
+++ b/ci-test.sh
@@ -32,7 +32,7 @@ function updateBuild() {
     mkdir -p $REPO/rhtap
     SETUP_ENV=$REPO/rhtap/env.sh
     cp rhtap/env.template.sh $SETUP_ENV
-    sed -i "s!\${{ values.image }}!quay.io/$MY_QUAY_USER/bootstrap!g" $SETUP_ENV
+    sed -i "s!\${{ values.image }}!$IMAGE_TO_BUILD!g" $SETUP_ENV
     sed -i "s!\${{ values.dockerfile }}!Dockerfile!g" $SETUP_ENV
     sed -i "s!\${{ values.buildContext }}!.!g" $SETUP_ENV
     sed -i "s!\${{ values.repoURL }}!$GITOPS_REPO_UPDATE!g" $SETUP_ENV
@@ -46,6 +46,13 @@ function updateBuild() {
     echo "export IGNORE_REKOR=$IGNORE_REKOR" >> $SETUP_ENV
     echo "export TUF_MIRROR=$TUF_MIRROR" >> $SETUP_ENV
     echo "# Update forced CI test $(date)" >> $SETUP_ENV
+
+    if [[ "$TEST_PRIVATE_REGISTRY" == "true" ]]; then
+        echo "WARNING Due to private repos, disabling ACS"
+        sed -i '/export DISABLE_ACS=/d' $SETUP_ENV
+        echo "export DISABLE_ACS=true" >> $SETUP_ENV
+    fi
+
     updateGitAndQuayRefs $SETUP_ENV
     cat $SETUP_ENV
 }

--- a/promote-pipeline.sh
+++ b/promote-pipeline.sh
@@ -19,7 +19,7 @@ fi
 cp -r rhtap $GITOPS/rhtap
 SETUP_ENV=$GITOPS/rhtap/env.sh
 cp rhtap/env.template.sh $SETUP_ENV
-sed -i "s!\${{ values.image }}!quay.io/$MY_QUAY_USER/bootstrap!g" $SETUP_ENV
+sed -i "s!\${{ values.image }}!$IMAGE_TO_BUILD!g" $SETUP_ENV
 sed -i "s!\${{ values.dockerfile }}!Dockerfile!g" $SETUP_ENV
 sed -i "s!\${{ values.buildContext }}!.!g" $SETUP_ENV
 sed -i "s!\${{ values.repoURL }}!!g" $SETUP_ENV

--- a/rhtap/download-sbom-from-url-in-attestation.sh
+++ b/rhtap/download-sbom-from-url-in-attestation.sh
@@ -120,6 +120,13 @@ fi
 
 jq -r '.components[].containerImage' <<< "$IMAGES" | while read -r image; do
     echo "Getting attestation for $image"
+
+    image_registry="${image/\/*/}"
+    # If the repo is not publicly accessible we need to authenticate so ec can access it
+    prepare-registry-user-pass $image_registry
+    echo "cosign login to registry $image_registry"
+    cosign login --username="$IMAGE_REGISTRY_USER" --password="$IMAGE_REGISTRY_PASSWORD" $image_registry
+
     mkdir -p "$WORKDIR/$image"
     cosign_verify_multiple_attestation_types \
         --type slsaprovenance02 \

--- a/rhtap/verify-enterprise-contract.sh
+++ b/rhtap/verify-enterprise-contract.sh
@@ -47,7 +47,8 @@ function validate() {
     local image_registry="${first_image_ref/\/*/}"
     # If the repo is not publicly accessible we need to authenticate so ec can access it
     prepare-registry-user-pass $image_registry
-    buildah login --username="$IMAGE_REGISTRY_USER" --password="$IMAGE_REGISTRY_PASSWORD" $image_registry
+    echo "cosign login to registry $image_registry"
+    cosign login --username="$IMAGE_REGISTRY_USER" --password="$IMAGE_REGISTRY_PASSWORD" $image_registry
 
     ec validate image \
         "--images" \

--- a/setup-local-dev-repos.sh
+++ b/setup-local-dev-repos.sh
@@ -102,6 +102,15 @@ GITLAB_GITOPS=$TMP_REPOS/gitlab-gitops
 JENKINS_BUILD=$TMP_REPOS/jenkins-build
 JENKINS_GITOPS=$TMP_REPOS/jenkins-gitops
 
+# Change this for public or private image testing
+export TEST_PRIVATE_REGISTRY=${TEST_PRIVATE_REGISTRY:-true}
+if [[ "$TEST_PRIVATE_REGISTRY" == "true" ]]; then
+    echo "Note, private image being built by ci-test, acs disabled"
+    IMAGE_TO_BUILD=quay.io/$MY_QUAY_USER/private-image
+else
+    IMAGE_TO_BUILD=quay.io/$MY_QUAY_USER/bootstrap
+fi
+
 cloneRepo $UPSTREAM_BUILD_REPO ${TEST_BUILD_REPO_SSH:-$TEST_BUILD_REPO} $TEST_BUILD_REPO $BUILD
 cloneRepo $UPSTREAM_GITOPS_REPO ${TEST_GITOPS_REPO_SSH:-$TEST_GITOPS_REPO} $TEST_GITOPS_REPO $GITOPS
 cloneRepo $UPSTREAM_BUILD_REPO ${TEST_BUILD_GITLAB_REPO_SSH:-$TEST_BUILD_GITLAB_REPO} $TEST_BUILD_GITLAB_REPO $GITLAB_BUILD


### PR DESCRIPTION
- also changed ci-test and setup to do private registry as default and disable ACS when you test this way... This is because ACS (shared QE instance) won't have your creds ...

You can switch back to public by setting TEST_PRIVATE_REGISTRY=false before running ci-test and other setups. 
TODO
-- the env file is being created in multiple places -- would be good to make that common in one place.
-- disabling ACS should only be done if reusing the QE instances that don't have your credentials 