### PR TITLE
ensure sbom dir is empty

### DIFF
--- a/rhtap/download-sbom-from-url-in-attestation.sh
+++ b/rhtap/download-sbom-from-url-in-attestation.sh
@@ -295,7 +295,8 @@ find_blob_url() {
       end' < "$attestation_file"
 }
 
-echo "Making sure $SBOMS_DIR directory exists"
+echo "Making sure $SBOMS_DIR directory exists and is empty prior to downloading"
+rm -rf "$SBOMS_DIR"
 mkdir -p "$SBOMS_DIR"
 
 jq -r '.components[].containerImage' <<< "$IMAGES" | while read -r image; do


### PR DESCRIPTION
The init.sh file is not run as part of the gitops pipeline so the SBOM dir was not being reset.    
This can result in multiple sboms being uploaded if you are using a long running Jenkins.