### PR TITLE
Update promote script

### DIFF
--- a/hack/rhtap-promote
+++ b/hack/rhtap-promote
@@ -81,9 +81,8 @@ function createPR() {
         return
     fi
     if grep -q github.com <<< "$REPO"; then
-        git push --set-upstream origin $BRANCH
-        gh repo set-default $MY_GITHUB_USER/$(basename $REPO .git)
-        gh pr create --title "$BRANCH" --body "$TITLE"
+        git push --set-upstream origin $BRANCH 
+        gh pr create --title "$BRANCH" --body "$TITLE"  -R $REPO
         return
     fi
 }

--- a/hack/rhtap-promote
+++ b/hack/rhtap-promote
@@ -81,8 +81,8 @@ function createPR() {
         return
     fi
     if grep -q github.com <<< "$REPO"; then
-        git push --set-upstream origin $BRANCH 
-        gh pr create --title "$BRANCH" --body "$TITLE"  -R $REPO
+        git push --set-upstream origin $BRANCH
+        gh pr create --title "$BRANCH" --body "$TITLE" -R $REPO
         return
     fi
 }


### PR DESCRIPTION
Clean up the generation of a PR script on Github. 
Old way set the default for gh which is not required if you pass the repo with -R.
Now it works for your org repos (useful for RHDH/RHTAP Templates) and your personal repos.
