### PR TITLE
expose REKOR and TUF in GH Actions and Jenkins

### DIFF
--- a/generated/gitops-template/githubactions/.github/workflows/gitops-promotion.yml
+++ b/generated/gitops-template/githubactions/.github/workflows/gitops-promotion.yml
@@ -27,6 +27,10 @@ env:
   IMAGE_REGISTRY_USER: ${{ secrets.IMAGE_REGISTRY_USER }}
   # Set this password for your specific registry
   IMAGE_REGISTRY_PASSWORD: ${{ secrets.IMAGE_REGISTRY_PASSWORD }}
+  # Set this only when using an external Rekor instance
+  REKOR_HOST: ${{ secrets.REKOR_HOST }}
+  # Set this only when using an external TUF instance
+  TUF_MIRROR: ${{ secrets.TUF_MIRROR }}
   # QUAY_IO_CREDS_USR: ${{ secrets.QUAY_IO_CREDS_USR }}
   # QUAY_IO_CREDS_PSW: ${{ secrets.QUAY_IO_CREDS_PSW }}
   # ARTIFACTORY_IO_CREDS_USR: ${{ secrets.ARTIFACTORY_IO_CREDS_USR }}
@@ -73,6 +77,10 @@ jobs:
             IMAGE_REGISTRY_USER: `${{ secrets.IMAGE_REGISTRY_USER }}`, 
             /* Set this password for your specific registry */
             IMAGE_REGISTRY_PASSWORD: `${{ secrets.IMAGE_REGISTRY_PASSWORD }}`, 
+            /* Set this only when using an external Rekor instance */
+            REKOR_HOST: `${{ secrets.REKOR_HOST }}`, 
+            /* Set this only when using an external TUF instance */
+            TUF_MIRROR: `${{ secrets.TUF_MIRROR }}`, 
             /*QUAY_IO_CREDS_USR: `${{ secrets.QUAY_IO_CREDS_USR }}`, */
             /*QUAY_IO_CREDS_PSW: `${{ secrets.QUAY_IO_CREDS_PSW }}`, */
             /*ARTIFACTORY_IO_CREDS_USR: `${{ secrets.ARTIFACTORY_IO_CREDS_USR }}`, */

--- a/generated/gitops-template/githubactions/.github/workflows/gitops-promotion.yml
+++ b/generated/gitops-template/githubactions/.github/workflows/gitops-promotion.yml
@@ -28,9 +28,9 @@ env:
   # Set this password for your specific registry
   IMAGE_REGISTRY_PASSWORD: ${{ secrets.IMAGE_REGISTRY_PASSWORD }}
   # Set this only when using an external Rekor instance
-  REKOR_HOST: ${{ secrets.REKOR_HOST }}
+  # REKOR_HOST: ${{ secrets.REKOR_HOST }}
   # Set this only when using an external TUF instance
-  TUF_MIRROR: ${{ secrets.TUF_MIRROR }}
+  # TUF_MIRROR: ${{ secrets.TUF_MIRROR }}
   # QUAY_IO_CREDS_USR: ${{ secrets.QUAY_IO_CREDS_USR }}
   # QUAY_IO_CREDS_PSW: ${{ secrets.QUAY_IO_CREDS_PSW }}
   # ARTIFACTORY_IO_CREDS_USR: ${{ secrets.ARTIFACTORY_IO_CREDS_USR }}
@@ -78,9 +78,9 @@ jobs:
             /* Set this password for your specific registry */
             IMAGE_REGISTRY_PASSWORD: `${{ secrets.IMAGE_REGISTRY_PASSWORD }}`, 
             /* Set this only when using an external Rekor instance */
-            REKOR_HOST: `${{ secrets.REKOR_HOST }}`, 
+            /*REKOR_HOST: `${{ secrets.REKOR_HOST }}`, */
             /* Set this only when using an external TUF instance */
-            TUF_MIRROR: `${{ secrets.TUF_MIRROR }}`, 
+            /*TUF_MIRROR: `${{ secrets.TUF_MIRROR }}`, */
             /*QUAY_IO_CREDS_USR: `${{ secrets.QUAY_IO_CREDS_USR }}`, */
             /*QUAY_IO_CREDS_PSW: `${{ secrets.QUAY_IO_CREDS_PSW }}`, */
             /*ARTIFACTORY_IO_CREDS_USR: `${{ secrets.ARTIFACTORY_IO_CREDS_USR }}`, */

--- a/generated/gitops-template/jenkins/Jenkinsfile
+++ b/generated/gitops-template/jenkins/Jenkinsfile
@@ -26,6 +26,10 @@ pipeline {
         QUAY_IO_CREDS = credentials('QUAY_IO_CREDS')
         /* ARTIFACTORY_IO_CREDS = credentials('ARTIFACTORY_IO_CREDS') */
         /* NEXUS_IO_CREDS = credentials('NEXUS_IO_CREDS') */
+        /* Set when using Jenkins on non-local cluster and using an external Rekor instance */
+        /* REKOR_HOST = credentials('REKOR_HOST') */
+        /* Set when using Jenkins on non-local cluster and using an external TUF instance */
+        /* TUF_MIRROR = credentials('TUF_MIRROR') */
     }
     stages {
         stage('Verify EC') {

--- a/generated/source-repo/githubactions/.github/workflows/build-and-update-gitops.yml
+++ b/generated/source-repo/githubactions/.github/workflows/build-and-update-gitops.yml
@@ -23,6 +23,10 @@ env:
   IMAGE_REGISTRY_USER: ${{ secrets.IMAGE_REGISTRY_USER }}
   # Set this password for your specific registry
   IMAGE_REGISTRY_PASSWORD: ${{ secrets.IMAGE_REGISTRY_PASSWORD }}
+  # Set this only when using an external Rekor instance
+  REKOR_HOST: ${{ secrets.REKOR_HOST }}
+  # Set this only when using an external TUF instance
+  TUF_MIRROR: ${{ secrets.TUF_MIRROR }}
   # QUAY_IO_CREDS_USR: ${{ secrets.QUAY_IO_CREDS_USR }}
   # QUAY_IO_CREDS_PSW: ${{ secrets.QUAY_IO_CREDS_PSW }}
   # ARTIFACTORY_IO_CREDS_USR: ${{ secrets.ARTIFACTORY_IO_CREDS_USR }}
@@ -74,6 +78,10 @@ jobs:
             IMAGE_REGISTRY_USER: `${{ secrets.IMAGE_REGISTRY_USER }}`, 
             /* Set this password for your specific registry */
             IMAGE_REGISTRY_PASSWORD: `${{ secrets.IMAGE_REGISTRY_PASSWORD }}`, 
+            /* Set this only when using an external Rekor instance */
+            REKOR_HOST: `${{ secrets.REKOR_HOST }}`, 
+            /* Set this only when using an external TUF instance */
+            TUF_MIRROR: `${{ secrets.TUF_MIRROR }}`, 
             /*QUAY_IO_CREDS_USR: `${{ secrets.QUAY_IO_CREDS_USR }}`, */
             /*QUAY_IO_CREDS_PSW: `${{ secrets.QUAY_IO_CREDS_PSW }}`, */
             /*ARTIFACTORY_IO_CREDS_USR: `${{ secrets.ARTIFACTORY_IO_CREDS_USR }}`, */

--- a/generated/source-repo/githubactions/.github/workflows/build-and-update-gitops.yml
+++ b/generated/source-repo/githubactions/.github/workflows/build-and-update-gitops.yml
@@ -24,9 +24,9 @@ env:
   # Set this password for your specific registry
   IMAGE_REGISTRY_PASSWORD: ${{ secrets.IMAGE_REGISTRY_PASSWORD }}
   # Set this only when using an external Rekor instance
-  REKOR_HOST: ${{ secrets.REKOR_HOST }}
+  # REKOR_HOST: ${{ secrets.REKOR_HOST }}
   # Set this only when using an external TUF instance
-  TUF_MIRROR: ${{ secrets.TUF_MIRROR }}
+  # TUF_MIRROR: ${{ secrets.TUF_MIRROR }}
   # QUAY_IO_CREDS_USR: ${{ secrets.QUAY_IO_CREDS_USR }}
   # QUAY_IO_CREDS_PSW: ${{ secrets.QUAY_IO_CREDS_PSW }}
   # ARTIFACTORY_IO_CREDS_USR: ${{ secrets.ARTIFACTORY_IO_CREDS_USR }}
@@ -79,9 +79,9 @@ jobs:
             /* Set this password for your specific registry */
             IMAGE_REGISTRY_PASSWORD: `${{ secrets.IMAGE_REGISTRY_PASSWORD }}`, 
             /* Set this only when using an external Rekor instance */
-            REKOR_HOST: `${{ secrets.REKOR_HOST }}`, 
+            /*REKOR_HOST: `${{ secrets.REKOR_HOST }}`, */
             /* Set this only when using an external TUF instance */
-            TUF_MIRROR: `${{ secrets.TUF_MIRROR }}`, 
+            /*TUF_MIRROR: `${{ secrets.TUF_MIRROR }}`, */
             /*QUAY_IO_CREDS_USR: `${{ secrets.QUAY_IO_CREDS_USR }}`, */
             /*QUAY_IO_CREDS_PSW: `${{ secrets.QUAY_IO_CREDS_PSW }}`, */
             /*ARTIFACTORY_IO_CREDS_USR: `${{ secrets.ARTIFACTORY_IO_CREDS_USR }}`, */

--- a/generated/source-repo/jenkins/Jenkinsfile
+++ b/generated/source-repo/jenkins/Jenkinsfile
@@ -23,6 +23,10 @@ pipeline {
         COSIGN_SECRET_PASSWORD = credentials('COSIGN_SECRET_PASSWORD')
         COSIGN_SECRET_KEY = credentials('COSIGN_SECRET_KEY')
         COSIGN_PUBLIC_KEY = credentials('COSIGN_PUBLIC_KEY')
+        /* Set when using Jenkins on non-local cluster and using an external Rekor instance */
+        /* REKOR_HOST = credentials('REKOR_HOST') */
+        /* Set when using Jenkins on non-local cluster and using an external TUF instance */
+        /* TUF_MIRROR = credentials('TUF_MIRROR') */
     }
     stages {
         stage('init') {

--- a/templates/data.yaml
+++ b/templates/data.yaml
@@ -31,9 +31,11 @@ build_secrets:
   - name: REKOR_HOST
     if: 'isGitHub'
     comment: "Set this only when using an external Rekor instance"
+    commented_out: true
   - name: TUF_MIRROR
     if: 'isGitHub'
     comment: "Set this only when using an external TUF instance"
+    commented_out: true
   - name: IMAGE_REGISTRY_USER
     if: '!isGitHub'
     commented_out: true
@@ -112,9 +114,11 @@ gitops_secrets:
   - name: REKOR_HOST
     if: 'isGitHub'
     comment: "Set this only when using an external Rekor instance"
+    commented_out: true
   - name: TUF_MIRROR
     if: 'isGitHub'
     comment: "Set this only when using an external TUF instance"
+    commented_out: true
   # other CIs in transition so comment out and leave Quay.io
   - name: IMAGE_REGISTRY_USER
     if: '!isGitHub'

--- a/templates/data.yaml
+++ b/templates/data.yaml
@@ -27,6 +27,13 @@ build_secrets:
   - name: IMAGE_REGISTRY_PASSWORD 
     if: 'isGitHub'
     comment: "Set this password for your specific registry" 
+  # Expose Rekor and TUF in GitHub Actions so they can be set by user in secrets
+  - name: REKOR_HOST
+    if: 'isGitHub'
+    comment: "Set this only when using an external Rekor instance"
+  - name: TUF_MIRROR
+    if: 'isGitHub'
+    comment: "Set this only when using an external TUF instance"
   - name: IMAGE_REGISTRY_USER
     if: '!isGitHub'
     commented_out: true
@@ -66,6 +73,15 @@ build_secrets:
   - name: COSIGN_SECRET_PASSWORD
   - name: COSIGN_SECRET_KEY
   - name: COSIGN_PUBLIC_KEY
+  # Rekor and TUF again, but there is a difference between GH Actions and Jenkins
+  - name: REKOR_HOST
+    if: 'isJenkins'
+    comment: "Set when using Jenkins on non-local cluster and using an external Rekor instance"
+    commented_out: true
+  - name: TUF_MIRROR
+    if: 'isJenkins'
+    comment: "Set when using Jenkins on non-local cluster and using an external TUF instance"
+    commented_out: true
 
 gitops_steps:
   - name: Verify EC
@@ -91,7 +107,14 @@ gitops_secrets:
     comment: "Set this to the user for your specific registry"
   - name: IMAGE_REGISTRY_PASSWORD 
     if: 'isGitHub'
-    comment: "Set this password for your specific registry" 
+    comment: "Set this password for your specific registry"
+  # Expose Rekor and TUF in GitHub Actions so they can be set by user in secrets
+  - name: REKOR_HOST
+    if: 'isGitHub'
+    comment: "Set this only when using an external Rekor instance"
+  - name: TUF_MIRROR
+    if: 'isGitHub'
+    comment: "Set this only when using an external TUF instance"
   # other CIs in transition so comment out and leave Quay.io
   - name: IMAGE_REGISTRY_USER
     if: '!isGitHub'
@@ -129,4 +152,13 @@ gitops_secrets:
     commented_out: true 
   - name: NEXUS_IO_CREDS_PSW
     if: '!isJenkins'  
-    commented_out: true 
+    commented_out: true
+  # Rekor and TUF again, but there is a difference between GH Actions and Jenkins
+  - name: REKOR_HOST
+    if: 'isJenkins'
+    comment: "Set when using Jenkins on non-local cluster and using an external Rekor instance"
+    commented_out: true
+  - name: TUF_MIRROR
+    if: 'isJenkins'
+    comment: "Set when using Jenkins on non-local cluster and using an external TUF instance"
+    commented_out: true


### PR DESCRIPTION
REKOR_HOST and TUF_MIRROR are not exposed and can't be set by users in secrets/credentials in GH Actions and Jenkins

Expose them in GH Actions.
When getting an environment variable from secrets, GitHub always creates an env var, it just sets it to an empty string when secret is not set. This is going to be handled in env.sh in template definitions

Add them to Jenkins too, but leave them commented out and let users uncomment them when needed

Related https://github.com/redhat-appstudio/tssc-sample-templates/pull/106