### PR TITLE
Remove note about ubuntu-20.04

### DIFF
--- a/generated/gitops-template/githubactions/.github/workflows/gitops-promotion.yml
+++ b/generated/gitops-template/githubactions/.github/workflows/gitops-promotion.yml
@@ -3,7 +3,7 @@
 # 💁 The Promotion Pipeline will:
 # - Checkout your repository
 # - Compute Promoted Images to Validate
-# - Perform Image EC Validations 
+# - Perform Image EC Validations
 # - Optionally update SBOMS
 
 name: TSSC-Promotion-Pipeline
@@ -49,7 +49,6 @@ on: [pull_request, workflow_dispatch]
 jobs:
   tssc-ci-cd:
     name: Build and send Image Update PR
-    # ubuntu-20.04 can also be used.
     runs-on: ubuntu-24.04
     container:
       image: quay.io/redhat-appstudio/rhtap-task-runner:latest

--- a/generated/source-repo/githubactions/.github/workflows/build-and-update-gitops.yml
+++ b/generated/source-repo/githubactions/.github/workflows/build-and-update-gitops.yml
@@ -54,7 +54,6 @@ on:
 jobs:
   tssc-ci-cd:
     name: Build and send Image Update PR
-    # ubuntu-20.04 can also be used.
     runs-on: ubuntu-24.04
     container:
       image: quay.io/redhat-appstudio/rhtap-task-runner:latest

--- a/templates/gitops-template/gitops-promotion.yml.njk
+++ b/templates/gitops-template/gitops-promotion.yml.njk
@@ -3,7 +3,7 @@
 # 💁 The Promotion Pipeline will:
 # - Checkout your repository
 # - Compute Promoted Images to Validate
-# - Perform Image EC Validations 
+# - Perform Image EC Validations
 # - Optionally update SBOMS
 
 name: TSSC-Promotion-Pipeline
@@ -33,7 +33,6 @@ on: [pull_request, workflow_dispatch]
 jobs:
   tssc-ci-cd:
     name: Build and send Image Update PR
-    # ubuntu-20.04 can also be used.
     runs-on: ubuntu-24.04
     container:
       image: quay.io/redhat-appstudio/rhtap-task-runner:latest

--- a/templates/source-repo/build-and-update-gitops.yml.njk
+++ b/templates/source-repo/build-and-update-gitops.yml.njk
@@ -39,7 +39,6 @@ on:
 jobs:
   tssc-ci-cd:
     name: Build and send Image Update PR
-    # ubuntu-20.04 can also be used.
     runs-on: ubuntu-24.04
     container:
       image: quay.io/redhat-appstudio/rhtap-task-runner:latest


### PR DESCRIPTION
GitHub has announced that ubuntu-20.04 will no longer be supported starting on April 1st, 2025. This commit removes the comment about using that image as an option in order to avoid confusion.