### PR TITLE
Add eyecatchers for the EC report

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,17 +6,17 @@ FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23@sha256:ca0c7
 
 WORKDIR /build
 
-COPY . .
+COPY ./tools .
 
 ENV GOBIN=/usr/local/bin/
 
 RUN \
-  cd tools/yq && \
+  cd yq && \
   go install -trimpath --mod=readonly github.com/mikefarah/yq/v4 && \
   yq --version
 
 RUN \
-  cd tools/syft && \
+  cd syft && \
   go install -trimpath --mod=readonly github.com/anchore/syft/cmd/syft && \
   syft version
 

--- a/rhtap/verify-enterprise-contract.sh
+++ b/rhtap/verify-enterprise-contract.sh
@@ -79,7 +79,9 @@ function report() {
 
 function report-json() {
     echo "Running $TASK_NAME:report-json"
+    echo "EC_EYECATCHER_BEGIN"
     cat "$HOMEDIR/report-json.json"
+    echo "EC_EYECATCHER_END"
 }
 
 function summary() {


### PR DESCRIPTION
This is required for displaying a human readable version of the EC report from the logs in the UI.

Ref: RHTAP-4019

Also added a change to reduce the context of the runner image build by only copying the `tools` directory in the Dockerfile.