### PR TITLE
fix: run update-deployment before acs-deploy-check

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 This repository contains the innerloop development environment for the Multi-CI translations from the RHTAP Pipelines. This repository can also be directly tested in the CI system as it includes a copy of a sample source app for RHTAP (node.js) as well as a gitops repo for that deployment. This may be moved to a separate repo in future dev mode builds.
 
 
- This repo includes Jenkins, Gitlab and Github Actions tests of the scripts
+This repo includes Jenkins, Gitlab and Github Actions tests of the scripts
 
 The tasks appear in the `rhtap` directory and are updated manually. Once updated they can be tested locally in the shell or pushed to the appropriate CI system and tested in that CI.
 

--- a/generated/source-repo/githubactions/.github/workflows/build-and-update-gitops.yml
+++ b/generated/source-repo/githubactions/.github/workflows/build-and-update-gitops.yml
@@ -132,6 +132,10 @@ jobs:
         bash /work/rhtap/buildah-rhtap.sh
         echo "• cosign-sign-attest"
         bash /work/rhtap/cosign-sign-attest.sh
+    - name: Deploy
+      run: |
+        echo "• update-deployment"
+        bash /work/rhtap/update-deployment.sh
     - name: Scan
       run: |
         echo "• acs-deploy-check"
@@ -140,10 +144,6 @@ jobs:
         bash /work/rhtap/acs-image-check.sh
         echo "• acs-image-scan"
         bash /work/rhtap/acs-image-scan.sh
-    - name: Deploy
-      run: |
-        echo "• update-deployment"
-        bash /work/rhtap/update-deployment.sh
     - name: Summary
       run: |
         echo "• show-sbom-rhdh"

--- a/generated/source-repo/gitlabci/.gitlab-ci.yml
+++ b/generated/source-repo/gitlabci/.gitlab-ci.yml
@@ -8,8 +8,8 @@ variables:
 stages:
   - init
   - build
-  - scan
   - deploy
+  - scan
   - summary
 
 init:
@@ -40,6 +40,17 @@ cosign-sign-attest:
     paths:
       - results/
 
+update-deployment:
+  stage: deploy
+  script:
+    - echo "• update-deployment"
+    - bash /work/rhtap/update-deployment.sh
+  artifacts:
+    paths:
+      - results/
+  rules: 
+    - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+
 acs-deploy-check:
   stage: scan
   script:
@@ -66,17 +77,6 @@ acs-image-scan:
   artifacts:
     paths:
       - results/
-
-update-deployment:
-  stage: deploy
-  script:
-    - echo "• update-deployment"
-    - bash /work/rhtap/update-deployment.sh
-  artifacts:
-    paths:
-      - results/
-  rules: 
-    - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
 
 show-sbom-rhdh:
   stage: summary

--- a/generated/source-repo/jenkins/Jenkinsfile
+++ b/generated/source-repo/jenkins/Jenkinsfile
@@ -49,6 +49,15 @@ pipeline {
             }
         }
 
+        stage('deploy') {
+            steps {
+                script {
+                    rhtap.info('update_deployment')
+                    rhtap.update_deployment()
+                }
+            }
+        }
+
         stage('scan') {
             steps {
                 script {
@@ -58,15 +67,6 @@ pipeline {
                     rhtap.acs_image_check()
                     rhtap.info('acs_image_scan')
                     rhtap.acs_image_scan()
-                }
-            }
-        }
-
-        stage('deploy') {
-            steps {
-                script {
-                    rhtap.info('update_deployment')
-                    rhtap.update_deployment()
                 }
             }
         }

--- a/rhtap.groovy
+++ b/rhtap.groovy
@@ -47,6 +47,10 @@ def cosign_sign_attest( ) {
     run_script ('cosign-sign-attest.sh')
 }
 
+def update_deployment( ) {
+    run_script ('update-deployment.sh')
+}
+
 def acs_deploy_check( ) {
     run_script ('acs-deploy-check.sh')
 }
@@ -57,10 +61,6 @@ def acs_image_check( ) {
 
 def acs_image_scan( ) {
     run_script ('acs-image-scan.sh')
-}
-
-def update_deployment( ) {
-    run_script ('update-deployment.sh')
 }
 
 def show_sbom_rhdh( ) {

--- a/rhtap/build-pipeline-steps.sh
+++ b/rhtap/build-pipeline-steps.sh
@@ -3,9 +3,9 @@
 run rhtap/init.sh
 run rhtap/buildah-rhtap.sh
 run rhtap/cosign-sign-attest.sh
+run rhtap/update-deployment.sh
 run rhtap/acs-deploy-check.sh
 run rhtap/acs-image-check.sh
 run rhtap/acs-image-scan.sh
-run rhtap/update-deployment.sh
 run rhtap/show-sbom-rhdh.sh
 run rhtap/summary.sh

--- a/templates/data.yaml
+++ b/templates/data.yaml
@@ -4,11 +4,11 @@ build_steps:
     substeps: [init]
   - name: build
     substeps: [buildah-rhtap, cosign-sign-attest]
+  - name: deploy
+    substeps: [update-deployment]
   - name: scan
     substeps: [acs-deploy-check, acs-image-check, acs-image-scan]
     concurrent: true
-  - name: deploy
-    substeps: [update-deployment]
   - name: summary
     substeps: [show-sbom-rhdh, summary]
     concurrent: true


### PR DESCRIPTION
'acs-deploy-check' checks out the gitops repository to validate the deployment, but that repository was updated after the check.