### PR TITLE
Use consistent invocationId attribute

### DIFF
--- a/rhtap/att-predicate-azure.sh
+++ b/rhtap/att-predicate-azure.sh
@@ -22,7 +22,7 @@ runDetails:
     id: "${AGENT_ID}"
 
   metadata:
-    invocationID: "${BUILD_BUILDURI}"
+    invocationId: "${BUILD_BUILDURI}"
     startedOn: "$(cat $BASE_RESULTS/init/START_TIME)"
     finishedOn: "$(timestamp)"
 

--- a/rhtap/att-predicate-jenkins.sh
+++ b/rhtap/att-predicate-jenkins.sh
@@ -32,7 +32,7 @@ runDetails:
       jobUrl: "${JOB_URL}"
 
   metadata:
-    invocationID: "${BUILD_TAG}"
+    invocationId: "${BUILD_TAG}"
     startedOn: "$(cat $BASE_RESULTS/init/START_TIME)"
     # Inaccurate, but maybe close enough
     finishedOn: "$(timestamp)"


### PR DESCRIPTION
Update the SLSA Provenance generation code to always use the `.runDetails.metadata.invocationId` attribute. In some cases, Azure and Jenkins, `invocationId` was written as `invocationID` (upper case `D`).

This follows the SLSA Provenance 1.0 spec:
https://slsa.dev/spec/v1.0/provenance#buildmetadata