### PR TITLE
Add .idea directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ render/node_modules/
 .env
 .envrc
 bin/shfmt
+.idea/**


### PR DESCRIPTION
.idea directory is used for storing settings of the IntelliJ-family of IDEs. It should not be included in the repository.