### PR TITLE
Fix login consolidation for buildah-rhtap

### DIFF
--- a/rhtap/buildah-rhtap.sh
+++ b/rhtap/buildah-rhtap.sh
@@ -7,14 +7,7 @@ source $SCRIPTDIR/common.sh
 
 function login() {
     echo "Running $TASK_NAME:login"
-    IMAGE_REGISTRY="${IMAGE%%/*}"
-    prepare-registry-user-pass $IMAGE_REGISTRY
-    buildah login --username="$IMAGE_REGISTRY_USER" --password="$IMAGE_REGISTRY_PASSWORD" $IMAGE_REGISTRY
-    ERR=$?
-    if [ $ERR != 0 ]; then
-        echo "Failed buildah login $IMAGE_REGISTRY for user $IMAGE_REGISTRY_USER "
-        exit $ERR
-    fi
+    registry-login "$IMAGE"
 }
 
 function build() {


### PR DESCRIPTION
In https://github.com/redhat-appstudio/tssc-dev-multi-ci/pull/158, the login cosolidation didn't take into account the buildah-rhtap script. This caused the `cosign` command running within that script to fail to upload SBOMs.

Ref: https://issues.redhat.com/browse/RHTAP-4565