### PR TITLE
Update go.mod version to reflect builder image

### DIFF
--- a/tools/syft/go.mod
+++ b/tools/syft/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhat-appstudio/tssc-dev-multi-ci/tools/syft
 
-go 1.23.2
+go 1.23.6
 
 require github.com/anchore/syft v1.19.0
 

--- a/tools/yq/go.mod
+++ b/tools/yq/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhat-appstudio/tssc-dev-multi-ci/tools/yq
 
-go 1.23.0
+go 1.23.6
 
 require github.com/mikefarah/yq/v4 v4.45.1
 


### PR DESCRIPTION
Update the version of specified in the go.mod files for yq and syft to reflect the go version used in the builder image from the Dockerfile.

The previous version had CVEs so this ensures those binaries are not built (in other contexts) with a vulnerable version of Go.