### PR TITLE
Switch task-runner image refs to Red Hat registry

### DIFF
--- a/ci-test.sh
+++ b/ci-test.sh
@@ -46,7 +46,7 @@ function updateGitAndQuayRefs() {
         echo "USE_RHTAP_IMAGES is set to $USE_RHTAP_IMAGES"
         echo "images or Jenkins references patched to quay.io/$MY_QUAY_USER and github.com/$MY_GITHUB_USER"
         if [ -f "$1" ]; then
-            SED_CMD "s!quay.io/redhat-appstudio/rhtap-task-runner.*!quay.io/$MY_QUAY_USER/rhtap-task-runner:dev!g" "$1"
+            SED_CMD "s!registry.access.redhat.com/rhtap-task-runner/rhtap-task-runner-rhel9.*!quay.io/$MY_QUAY_USER/rhtap-task-runner:dev!g" "$1"
             SED_CMD "s!https://github.com/redhat-appstudio!https://github.com/$MY_GITHUB_USER!g" "$1"
             SED_CMD "s!RHTAP_Jenkins@.*'!RHTAP_Jenkins@dev'!g" "$1"
         fi

--- a/generated/gitops-template/azure/azure-pipelines.yml
+++ b/generated/gitops-template/azure/azure-pipelines.yml
@@ -11,7 +11,7 @@ pool:
   name: Default
 
 container:
-  image: quay.io/redhat-appstudio/rhtap-task-runner:1.5
+  image: registry.access.redhat.com/rhtap-task-runner/rhtap-task-runner-rhel9:1.5
   options: --privileged
 
 # Using 'rhtap' variable group by default

--- a/generated/gitops-template/githubactions/.github/workflows/gitops-promotion.yml
+++ b/generated/gitops-template/githubactions/.github/workflows/gitops-promotion.yml
@@ -53,7 +53,7 @@ jobs:
     name: Build and send Image Update PR
     runs-on: ubuntu-24.04
     container:
-      image: quay.io/redhat-appstudio/rhtap-task-runner:1.5
+      image: registry.access.redhat.com/rhtap-task-runner/rhtap-task-runner-rhel9:1.5
       options: --privileged
     environment: production
 

--- a/generated/gitops-template/gitlabci/.gitlab-ci.yml
+++ b/generated/gitops-template/gitlabci/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 # Generated from templates/gitops-template/.gitlab-ci.yml.njk. Do not edit directly.
 
-image: quay.io/redhat-appstudio/rhtap-task-runner:1.5
+image: registry.access.redhat.com/rhtap-task-runner/rhtap-task-runner-rhel9:1.5
 
 variables:
   CI_TYPE: gitlab

--- a/generated/source-repo/azure/azure-pipelines.yml
+++ b/generated/source-repo/azure/azure-pipelines.yml
@@ -11,7 +11,7 @@ pool:
   name: Default
 
 container:
-  image: quay.io/redhat-appstudio/rhtap-task-runner:1.5
+  image: registry.access.redhat.com/rhtap-task-runner/rhtap-task-runner-rhel9:1.5
   options: --privileged
 
 # Using 'rhtap' variable group by default

--- a/generated/source-repo/githubactions/.github/workflows/build-and-update-gitops.yml
+++ b/generated/source-repo/githubactions/.github/workflows/build-and-update-gitops.yml
@@ -61,7 +61,7 @@ jobs:
     name: Build and send Image Update PR
     runs-on: ubuntu-24.04
     container:
-      image: quay.io/redhat-appstudio/rhtap-task-runner:1.5
+      image: registry.access.redhat.com/rhtap-task-runner/rhtap-task-runner-rhel9:1.5
       options: --privileged
     environment: production
 

--- a/generated/source-repo/gitlabci/.gitlab-ci.yml
+++ b/generated/source-repo/gitlabci/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 # Generated from templates/source-repo/.gitlab-ci.yml.njk. Do not edit directly.
 
-image: quay.io/redhat-appstudio/rhtap-task-runner:1.5
+image: registry.access.redhat.com/rhtap-task-runner/rhtap-task-runner-rhel9:1.5
 
 variables:
   CI_TYPE: gitlab

--- a/templates/gitops-template/.gitlab-ci.yml.njk
+++ b/templates/gitops-template/.gitlab-ci.yml.njk
@@ -1,6 +1,6 @@
 {%- include "do-not-edit.njk" -%}
 
-image: quay.io/redhat-appstudio/rhtap-task-runner:1.5
+image: registry.access.redhat.com/rhtap-task-runner/rhtap-task-runner-rhel9:1.5
 
 variables:
   CI_TYPE: gitlab

--- a/templates/gitops-template/azure-pipelines.yml.njk
+++ b/templates/gitops-template/azure-pipelines.yml.njk
@@ -12,7 +12,7 @@ pool:
   name: Default
 
 container:
-  image: quay.io/redhat-appstudio/rhtap-task-runner:1.5
+  image: registry.access.redhat.com/rhtap-task-runner/rhtap-task-runner-rhel9:1.5
   options: --privileged
 
 # Using 'rhtap' variable group by default

--- a/templates/gitops-template/gitops-promotion.yml.njk
+++ b/templates/gitops-template/gitops-promotion.yml.njk
@@ -36,7 +36,7 @@ jobs:
     name: Build and send Image Update PR
     runs-on: ubuntu-24.04
     container:
-      image: quay.io/redhat-appstudio/rhtap-task-runner:1.5
+      image: registry.access.redhat.com/rhtap-task-runner/rhtap-task-runner-rhel9:1.5
       options: --privileged
     environment: production
 

--- a/templates/source-repo/.gitlab-ci.yml.njk
+++ b/templates/source-repo/.gitlab-ci.yml.njk
@@ -1,6 +1,6 @@
 {%- include "do-not-edit.njk" -%}
 
-image: quay.io/redhat-appstudio/rhtap-task-runner:1.5
+image: registry.access.redhat.com/rhtap-task-runner/rhtap-task-runner-rhel9:1.5
 
 variables:
   CI_TYPE: gitlab

--- a/templates/source-repo/azure-pipelines.yml.njk
+++ b/templates/source-repo/azure-pipelines.yml.njk
@@ -12,7 +12,7 @@ pool:
   name: Default
 
 container:
-  image: quay.io/redhat-appstudio/rhtap-task-runner:1.5
+  image: registry.access.redhat.com/rhtap-task-runner/rhtap-task-runner-rhel9:1.5
   options: --privileged
 
 # Using 'rhtap' variable group by default

--- a/templates/source-repo/build-and-update-gitops.yml.njk
+++ b/templates/source-repo/build-and-update-gitops.yml.njk
@@ -46,7 +46,7 @@ jobs:
     name: Build and send Image Update PR
     runs-on: ubuntu-24.04
     container:
-      image: quay.io/redhat-appstudio/rhtap-task-runner:1.5
+      image: registry.access.redhat.com/rhtap-task-runner/rhtap-task-runner-rhel9:1.5
       options: --privileged
     environment: production
 


### PR DESCRIPTION
Starting with RHTAP release 1.5, we are releasing the runner image to registry.access.redhat.com.