### PR TITLE
Add image_digest parameter to sast-coverity check

### DIFF
--- a/.tekton/rhtap-task-runner-1-5-pull-request.yaml
+++ b/.tekton/rhtap-task-runner-1-5-pull-request.yaml
@@ -427,6 +427,8 @@ spec:
       params:
       - name: image-url
         value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: IMAGE
         value: $(params.output-image)
       - name: DOCKERFILE

--- a/.tekton/rhtap-task-runner-1-5-push.yaml
+++ b/.tekton/rhtap-task-runner-1-5-push.yaml
@@ -424,6 +424,8 @@ spec:
       params:
       - name: image-url
         value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: IMAGE
         value: $(params.output-image)
       - name: DOCKERFILE


### PR DESCRIPTION
New version of sast-coverity-check task requires a parameter image_digest.