### PR TITLE
Add runner image from main to default list

### DIFF
--- a/hack/wait-for-gitops-update.sh
+++ b/hack/wait-for-gitops-update.sh
@@ -8,6 +8,7 @@ JENKINS_REPO=https://github.com/$MY_GITHUB_USER/tssc-dev-gitops-jenkins
 DEFAULT_INIT_IMAGES=(
     'quay.io/redhat-appstudio/dance-bootstrap-app'
     'registry.access.redhat.com/rhtap-task-runner/rhtap-task-runner-rhel9'
+    'quay.io/redhat-appstudio/rhtap-task-runner'
 )
 
 WORK=$(mktemp -d)

--- a/rhtap/gather-deploy-images.sh
+++ b/rhtap/gather-deploy-images.sh
@@ -6,6 +6,7 @@ source $SCRIPTDIR/common.sh
 DEFAULT_INIT_IMAGES=(
     'quay.io/redhat-appstudio/dance-bootstrap-app'
     'registry.access.redhat.com/rhtap-task-runner/rhtap-task-runner-rhel9'
+    'quay.io/redhat-appstudio/rhtap-task-runner'
 )
 
 function get-images-per-env() {


### PR DESCRIPTION
Add the runner image that is built and released from the main branch to the list of default init images. This allows us to perform pre-release tests more accurately.