### PR TITLE
Use release branch for Jenkins library

### DIFF
--- a/generated/gitops-template/jenkins/Jenkinsfile
+++ b/generated/gitops-template/jenkins/Jenkinsfile
@@ -1,6 +1,6 @@
 /* Generated from templates/gitops-template/Jenkinsfile.njk. Do not edit directly. */
 
-library identifier: 'RHTAP_Jenkins@v1.6', retriever: modernSCM(
+library identifier: 'RHTAP_Jenkins@release-v1.6.x', retriever: modernSCM(
   [$class: 'GitSCMSource',
    remote: 'https://github.com/redhat-appstudio/tssc-sample-jenkins.git'])
 

--- a/generated/source-repo/jenkins/Jenkinsfile
+++ b/generated/source-repo/jenkins/Jenkinsfile
@@ -1,6 +1,6 @@
 /* Generated from templates/source-repo/Jenkinsfile.njk. Do not edit directly. */
 
-library identifier: 'RHTAP_Jenkins@v1.6', retriever: modernSCM(
+library identifier: 'RHTAP_Jenkins@release-v1.6.x', retriever: modernSCM(
   [$class: 'GitSCMSource',
    remote: 'https://github.com/redhat-appstudio/tssc-sample-jenkins.git'])
 

--- a/templates/partials/jenkins-library-source.njk
+++ b/templates/partials/jenkins-library-source.njk
@@ -1,4 +1,4 @@
-library identifier: 'RHTAP_Jenkins@v1.6', retriever: modernSCM(
+library identifier: 'RHTAP_Jenkins@release-v1.6.x', retriever: modernSCM(
   [$class: 'GitSCMSource',
    remote: 'https://github.com/redhat-appstudio/tssc-sample-jenkins.git'])
 {{- nlnl -}}


### PR DESCRIPTION
Modify the Jenkinsfiles so the Jenkins library is referenced by a branch instead of a tag. This facilitates pushing bug fixes to users.

This is the corresponding change done directly in the templates repo: https://github.com/redhat-appstudio/tssc-sample-templates/pull/157
Adding it here so it doesn't get reverted when syncing.