### PR TITLE
Prevent unintended Azure pipeline runs

### DIFF
--- a/generated/gitops-template/azure/azure-pipelines.yml
+++ b/generated/gitops-template/azure/azure-pipelines.yml
@@ -3,6 +3,8 @@
 pr:
   - main
 
+trigger: none
+
 # Using self-hosted 'Default' agent pool by default
 # Change accordingly when using a different agent pool
 # Can be deleted if self-hosted agents are not being used

--- a/generated/source-repo/azure/azure-pipelines.yml
+++ b/generated/source-repo/azure/azure-pipelines.yml
@@ -1,5 +1,7 @@
 # Generated from templates/source-repo/azure-pipelines.yml.njk. Do not edit directly.
 
+pr: none
+
 trigger:
   - main
 

--- a/templates/gitops-template/azure-pipelines.yml.njk
+++ b/templates/gitops-template/azure-pipelines.yml.njk
@@ -4,6 +4,8 @@
 pr:
   - main
 
+trigger: none
+
 # Using self-hosted 'Default' agent pool by default
 # Change accordingly when using a different agent pool
 # Can be deleted if self-hosted agents are not being used

--- a/templates/source-repo/azure-pipelines.yml.njk
+++ b/templates/source-repo/azure-pipelines.yml.njk
@@ -1,6 +1,8 @@
 {%- include "do-not-edit.njk" -%}
 {%- set secrets = build_secrets -%}
 
+pr: none
+
 trigger:
   - main
 


### PR DESCRIPTION
By default, if an Azure pipeline does not define a `pr` attribute, Azure takes the default behavior of running the pipeline for *every* pull request.

Similarly, if the `trigger` attribute is not defined, the pipeline runs for push commits on *every* branch in the repo.

It is possible to change this default behavior on the Azure side: https://learn.microsoft.com/en-us/azure/devops/release-notes/2023/sprint-227-update#prevent-unintended-pipeline-runs

However, since these pipelines are only ever meant to be executed on specific events, we can change the default behavior by setting the `pr` and the `trigger` attributes to `none` where they weren't previously defined.

Ref: https://issues.redhat.com/browse/RHTAP-5246