### PR TITLE
Handle empty severe_violations variable

### DIFF
--- a/rhtap/acs-image-check.sh
+++ b/rhtap/acs-image-check.sh
@@ -64,7 +64,7 @@ function rox-image-check() {
     )
 
     # If roxctl image check exited with non-zero code and it is not because of policy violations, report error
-    if [ "$severe_violations" -eq 0 ]; then
+    if [[ "$severe_violations" -eq 0 ]]; then
         exit "$ROXCTL_CHECK_STATUS"
     fi
 }


### PR DESCRIPTION
The `severe_violations` variable is being created by jq which counts critical and high severity violations in a json file generated in previous step.
If the json file is empty, the `severe_violations` variable is also empty.

Checking an empty variable with `[` and the `-eq` operator leads to a `integer expression expected` error in Bash (but not in Z shell) resulting to a failure in logic and the Task unexpectedly passing.

However, using `[[` works as expected and considers an empty string and 0 to be equal.

```
bash-5.2$ [ "" -eq 0 ] && echo equal || echo not
bash: [: : integer expression expected
not
bash-5.2$ [[ "" -eq 0 ]] && echo equal || echo not
equal
```