### PR TITLE
Add reduce-snapshot.sh script to runner image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ RUN \
 
 COPY --from=cosign /usr/local/bin/cosign /usr/bin/cosign
 COPY --from=ec /usr/local/bin/ec /usr/bin/ec
+COPY --from=ec /usr/local/bin/reduce-snapshot.sh /usr/bin/reduce-snapshot.sh
 COPY --from=go-builder /usr/local/bin/yq /usr/bin/yq
 COPY --from=go-builder /usr/local/bin/syft /usr/bin/syft
 COPY --from=go-builder /usr/local/bin/splashy /usr/bin/splashy


### PR DESCRIPTION
As part of RHTAP-5277, we want to start using the runner image in the Tekton Tasks. The verify-ec Task uses the reduce-snapshot.sh script in one of its steps. This commit adds the script from the official EC image to the runner image.