### PR TITLE
Remove chunked encoding

### DIFF
--- a/rhtap/upload-sbom-to-trustification.sh
+++ b/rhtap/upload-sbom-to-trustification.sh
@@ -186,21 +186,20 @@ for sbom_path in "${sboms_to_upload[@]}"; do
     token_type="$(jq -r .token_type <<< "$token_response")"
     expires_in="$(jq -r ".expires_in // empty" <<< "$token_response")"
 
-    retry_max_time=0 # no limit
+    retry_max_time=600 # 10 minutes as the default value
     if [[ -n "$expires_in" ]]; then
-        retry_max_time="$expires_in"
+        retry_max_time="$expires_in" # Adjust timeout to match token expiration
     fi
 
     # This sbom_id is the one created in the gather-sboms step - sha256:${checksum}
     sbom_id="$(basename -s .json "$sbom_path")"
     supported_version_of_sbom="${sbom_path}.supported_version"
 
-    echo "Uploading SBOM to $bombastic_api_url (with id=$sbom_id)"
+    echo "Uploading SBOM to $bombastic_api_url (with id=$sbom_id) [retry_max_time=$retry_max_time]"
     # https://docs.trustification.dev/trustification/user/bombastic.html#publishing-an-sbom-doc
     curl "${curl_opts[@]}" \
         --retry-max-time "$retry_max_time" \
         -H "authorization: $token_type $access_token" \
-        -H "transfer-encoding: chunked" \
         -H "content-type: application/json" \
         --data "@$supported_version_of_sbom" \
         "$bombastic_api_url/api/v2/sbom?id=$sbom_id"


### PR DESCRIPTION
In some cases, 'transfer-encoding: chunked' is causing curl to hang indefinetly when uploading an SBOM. There are two reasons one may want to use this chunked encoding.

First, if the length of the content being uploaded is unknown. This is not the case here since we have the full file before making the API call.

Second, if the file being uploaded is excessively large, the targeted server may require the data to be streamed via chunks. Although SBOMs can be quite large, we don't seem to be anywhere near it. (The limit on TPA is currently not documented.)

It is also important to call out that when using chunked encoding, "the content-length header must be omitted":
https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Transfer-Encoding#chunked

For these reasonse, this commit removes the chunked encoding.

Additionally, the default `retry-max-timeout` is changed from 0 (no timeout) to 10 minutes which should be quite generous. The default value is used if the token doesn't provide its own expiration.