### PR TITLE
acs-image-check: emit report on success

### DIFF
--- a/rhtap/acs-image-check.sh
+++ b/rhtap/acs-image-check.sh
@@ -50,7 +50,7 @@ function rox-image-check() {
         ROXCTL_CHECK_STATUS=$?
 
     if [ "$ROXCTL_CHECK_STATUS" -eq 0 ]; then
-        exit
+        return
     fi
 
     # Number of policy violations with Critical and High severity parsed from the report


### PR DESCRIPTION
If there are no main issues found with the roxctl command, it exits with a 0 return code. Previously, the `acs-image-check` script would just do exit early if that happened. This caused the eyecatcher report to be omitted. This commit fixes that by returning from that function instead of exiting the script completely.