### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for rhtap-task-runner-1-5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,8 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5-1742914212@sha256:ac61c96b9
 
 # required per https://github.com/release-engineering/rhtap-ec-policy/blob/main/data/rule_data.yml
 LABEL com.redhat.component="rhtap-task-runner"
-LABEL name="rhtap-task-runner"
+LABEL name="rhtap-task-runner/rhtap-task-runner-rhel9"
+LABEL cpe="cpe:/a:redhat:trusted_application_pipeline:1.5::el9"
 LABEL version="1.5.0"
 LABEL release="1"
 LABEL summary="RHTAP Task Runner"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
