### PR TITLE
Testing cosign v3, TAS 1.4 pre-release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM registry.redhat.io/rhtas/cosign-rhel9:1.3.2@sha256:a8289d488491991d454a32784de19476f2c984917eb7a33b4544e55512f2747c as cosign
+FROM quay.io/securesign/cli-cosign@sha256:be9bda33512e33d56ea6f20f29c81f31017a3ff4815d333502fcaef6c65bd85b as cosign
 
-FROM registry.redhat.io/rhtas/ec-rhel9:0.7-1772025373@sha256:d864cad870adad9df23ce860e8c31eb86f61201b408ed00d01fec00714569fd1 as ec
+FROM registry.redhat.io/rhtas/ec-rhel9:0.8@sha256:db0c40dcc9a8ad2015af8b4d894f1434c9397a66b2919d81c1f323134d12bb5a as ec
 
 FROM registry.redhat.io/openshift4/ose-cli:latest@sha256:ef83967297f619f45075e7fd1428a1eb981622a6c174c46fb53b158ed24bed85 as oc
 

--- a/integration-tests/config/testplan.json
+++ b/integration-tests/config/testplan.json
@@ -2,13 +2,8 @@
   "testPlans": [
     {
       "name": "e2e-tests",
-      "templates": ["go","python","dotnet-basic","nodejs","java-quarkus","java-springboot"],
+      "templates": ["go"],
       "tssc": [{
-        "git": "github",
-        "ci": "tekton",
-        "registry": "quay"
-      },
-      {
         "git": "github",
         "ci": "azure",
         "registry": "quay"

--- a/tssc/att-predicate-azure.sh
+++ b/tssc/att-predicate-azure.sh
@@ -19,7 +19,7 @@ buildDefinition:
 
 runDetails:
   builder:
-    id: "${AGENT_ID}"
+    id: "${SYSTEM_COLLECTIONURI}${SYSTEM_TEAMPROJECT}/_builders/${AGENT_ID}"
 
   metadata:
     invocationId: "${BUILD_BUILDURI}"

--- a/tssc/cosign-sign-attest.sh
+++ b/tssc/cosign-sign-attest.sh
@@ -6,6 +6,9 @@ SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
 # cosign-sign-attest
 source $SCRIPTDIR/common.sh
 
+echo "Checking cosign version"
+cosign version
+
 base64d() {
     base64 -d <<< "$1"
 }
@@ -69,7 +72,7 @@ function login() {
 # vars COSIGN_SECRET_PASSWORD and COSIGN_SECRET_KEY.
 function sign() {
     echo "Running $TASK_NAME:sign"
-    cosign-cmd sign
+    cosign-cmd sign --use-signing-config=false
 }
 
 # Create provenance predicate and use it to cosign attest the image
@@ -77,8 +80,13 @@ function attest() {
     echo "Running $TASK_NAME:attest"
     # Put the predicate file in the results also for debugging purposes
     create-att-predicate > "$RESULTS/att-predicate.json"
+
+    echo "--- Verifying SLSA Builder ID ---"
+    yq '.runDetails.builder.id' "$RESULTS/att-predicate.json"
+    echo "---------------------------------"
+
     # (Assume we did cosign login already)
-    cosign-cmd attest --predicate "$RESULTS/att-predicate.json" --type slsaprovenance1
+    cosign-cmd attest --predicate "$RESULTS/att-predicate.json" --type slsaprovenance1 --use-signing-config=false
 }
 
 function show-rekor-url() {


### PR DESCRIPTION
Using custom image for azure CI to test expected cosign v3 in TAS 1.4

Simplifying test plan to only target Azure CI and go language

DON'T MERGE